### PR TITLE
Interactive Tabs: Save last viewed tab in localStorage -> enable with data-tabs-save

### DIFF
--- a/content/components/tabs.md
+++ b/content/components/tabs.md
@@ -152,7 +152,7 @@ If you want to show the tabs on the full width relative to the parent element yo
   {{< requires_js >}}
 </div>
 
-## Interactivee tabs
+## Interactive tabs
 
 Use the dynamic tabs component to interactively show and hide the content below the tabs based on the currently active tab item. Make sure that you initialize the component by using the `data-tabs-toggle="{parentTabContentSelector}"` and also apply an `id` attribute to the same element.
 

--- a/content/components/tabs.md
+++ b/content/components/tabs.md
@@ -152,7 +152,7 @@ If you want to show the tabs on the full width relative to the parent element yo
   {{< requires_js >}}
 </div>
 
-## Interactive tabs
+## Interactivee tabs
 
 Use the dynamic tabs component to interactively show and hide the content below the tabs based on the currently active tab item. Make sure that you initialize the component by using the `data-tabs-toggle="{parentTabContentSelector}"` and also apply an `id` attribute to the same element.
 
@@ -162,17 +162,19 @@ You must also apply the `role="tabpanel"` data attribute to every tab content el
 
 You can use multiple tab components on a single page but make sure that the id's are different.
 
+If you want to keep the currently active tab active even after reloading the page, you can use `data-tabs-save`. If the site is reloaded while a tab/toggle with this attribute is active, it will stay active. If this attribute is not set, the active tab will reset to the last opened tab with attribute `data-tabs-save`. If no tab has the attribute, it will always fall back to the tab with the `aria-selected="true"` data attribute.
+
 {{< example >}}
 <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
     <ul class="flex flex-wrap -mb-px" id="myTab" data-tabs-toggle="#myTabContent" role="tablist">
         <li class="mr-2" role="presentation">
-            <button class="inline-block py-4 px-4 text-sm font-medium text-center text-gray-500 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300" id="profile-tab" data-tabs-target="#profile" type="button" role="tab" aria-controls="profile" aria-selected="false">Profile</button>
+            <button class="inline-block py-4 px-4 text-sm font-medium text-center text-gray-500 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300" id="profile-tab" data-tabs-target="#profile" data-tabs-save type="button" role="tab" aria-controls="profile" aria-selected="false">Profile</button>
         </li>
         <li class="mr-2" role="presentation">
-            <button class="inline-block py-4 px-4 text-sm font-medium text-center text-gray-500 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300 active" id="dashboard-tab" data-tabs-target="#dashboard" type="button" role="tab" aria-controls="dashboard" aria-selected="true">Dashboard</button>
+            <button class="inline-block py-4 px-4 text-sm font-medium text-center text-gray-500 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300 active" id="dashboard-tab" data-tabs-target="#dashboard" data-tabs-save type="button" role="tab" aria-controls="dashboard" aria-selected="true">Dashboard</button>
         </li>
         <li class="mr-2" role="presentation">
-            <button class="inline-block py-4 px-4 text-sm font-medium text-center text-gray-500 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300" id="settings-tab" data-tabs-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false">Settings</button>
+            <button class="inline-block py-4 px-4 text-sm font-medium text-center text-gray-500 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300" id="settings-tab" data-tabs-target="#settings" data-tabs-save type="button" role="tab" aria-controls="settings" aria-selected="false">Settings</button>
         </li>
         <li role="presentation">
             <button class="inline-block py-4 px-4 text-sm font-medium text-center text-gray-500 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300" id="contacts-tab" data-tabs-target="#contacts" type="button" role="tab" aria-controls="contacts" aria-selected="false">Contacts</button>
@@ -181,16 +183,16 @@ You can use multiple tab components on a single page but make sure that the id's
 </div>
 <div id="myTabContent">
     <div class="hidden p-4 bg-gray-50 rounded-lg dark:bg-gray-800" id="profile" role="tabpanel" aria-labelledby="profile-tab">
-        <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Profile tab's associated content</strong>. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Profile tab's associated content</strong>. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. This tab will stay active after reloading.</p>
     </div>
     <div class="p-4 bg-gray-50 rounded-lg dark:bg-gray-800" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab">
-        <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Dashboard tab's associated content</strong>. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Dashboard tab's associated content</strong>. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. This tab will stay active after reloading.</p>
     </div>
     <div class="hidden p-4 bg-gray-50 rounded-lg dark:bg-gray-800" id="settings" role="tabpanel" aria-labelledby="settings-tab">
-        <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Settings tab's associated content</strong>. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Settings tab's associated content</strong>. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. This tab will stay active after reloading.</p>
     </div>
     <div class="hidden p-4 bg-gray-50 rounded-lg dark:bg-gray-800" id="contacts" role="tabpanel" aria-labelledby="contacts-tab">
-        <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Contacts tab's associated content</strong>. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Contacts tab's associated content</strong>. Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling. This tab will <strong>not</strong> stay active after reloading.</p>
     </div>
 </div>
 {{< /example >}}

--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -12,6 +12,11 @@ document.querySelectorAll('[data-tabs-toggle]').forEach(function (tabsToggleEl) 
             var tabTargetSelector = tabToggleEl.getAttribute('data-tabs-target');
             var tabContentEl = document.querySelector(tabTargetSelector);
 
+            // save as last tab if has attribute data-tabs-save
+            if(tabToggleEl.getAttribute('data-tabs-save') !== null){
+                localStorage.setItem('dataTabSave', tabToggleEl.getAttribute('id'));
+            }
+
             // don't do anything if it's already active
             if (tabToggleEl !== activeTabToggleEl) {
 
@@ -21,15 +26,15 @@ document.querySelectorAll('[data-tabs-toggle]').forEach(function (tabsToggleEl) 
                     activeTabContentEl = document.querySelector(activeTabToggleEl.getAttribute('data-tabs-target'));
                 }
 
-                // show and activate tab
-                tabToggleEl.classList.add('active');
-                tabToggleEl.setAttribute('aria-selected', true);
-                tabContentEl.classList.remove('hidden');
-
                 // hide and deactive currently active tab toggle and content
                 activeTabToggleEl.setAttribute('aria-selected', false);
                 activeTabToggleEl.classList.remove('active');
                 activeTabContentEl.classList.add('hidden');
+
+                // show and activate tab
+                tabToggleEl.classList.add('active');
+                tabToggleEl.setAttribute('aria-selected', true);
+                tabContentEl.classList.remove('hidden');
 
                 // set currently active toggle and content tabs
                 activeTabToggleEl = tabToggleEl;
@@ -38,4 +43,10 @@ document.querySelectorAll('[data-tabs-toggle]').forEach(function (tabsToggleEl) 
 
         });
     });
+
+    // load most recent tab safe from local storage
+    var localTabSave = localStorage.getItem('dataTabSave');
+    if(localTabSave !== null){
+        document.getElementById(localTabSave).click();
+    }
 });


### PR DESCRIPTION
Updated both the docs tabs.md as well as the component tabs.js.

It is now possible to save the last open tab by adding `data-tabs-save` to the toggle element. No value needed as this is a boolean.

Exact functionality described in commit of tabs.js. ae1fc7d3f2f9dd26f8a2e27cdc2bcf7414e37652