### PR TITLE
holds ref to already active tab if exists or null

### DIFF
--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -5,8 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const tabsToggleElementsId = tabsToggleEl.getAttribute('id');
         const tabsToggleElements = document.querySelectorAll('#' + tabsToggleElementsId + ' [role="tab"]');
 
-        var activeTabToggleEl = null;
-        var activeTabContentEl = null;
+        var activeTabToggleEl = document.querySelector('#' + tabsToggleElementsId + ' [aria-selected="true"]');
+        var activeTabContentEl = document.querySelector(activeTabToggleEl.getAttribute('data-tabs-target'));
 
         tabsToggleElements.forEach(function (tabToggleEl) {
             tabToggleEl.addEventListener('click', function (event) {


### PR DESCRIPTION
this fixes the issue where clicking on the already tab hides its tab content