### PR TITLE
Fix: Remove white space on URL

### DIFF
--- a/layouts/shortcodes/requires_laravel.html
+++ b/layouts/shortcodes/requires_laravel.html
@@ -1,6 +1,6 @@
 <aside>
     <div class="mb-5">
-        <a href="{{ " getting-started/laravel/" | relURL }}"
+        <a href="{{ "getting-started/laravel/" | relURL }}"
             class="inline-flex justify-between items-center py-1 px-1 pr-4 text-sm text-gray-700 bg-gray-100 rounded-full dark:bg-gray-800 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-700"
             role="alert">
             <span class="text-xs text-[#ff2d20] rounded-full bg-white dark:bg-gray-900 px-3 py-1.5 mr-3">


### PR DESCRIPTION
Fix: Remove white space on URL that make it 404 not found.
There's "%20" in the link that cause 404 error.