### PR TITLE
Fix: Requires JS button URL

### DIFF
--- a/layouts/shortcodes/requires_js.html
+++ b/layouts/shortcodes/requires_js.html
@@ -1,5 +1,5 @@
 <aside>
-  <a href="{{ " getting-started/quickstart/" | relURL }}"
+  <a href="{{ "getting-started/quickstart/" | relURL }}"
     class="inline-flex justify-between items-center py-1 px-1 pr-4 text-sm text-gray-700 bg-gray-100 rounded-full dark:bg-gray-800 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-700"
     role="alert">
     <span class="text-xs bg-blue-600 rounded-full text-white px-3 py-1.5 mr-3"><svg class="w-4 h-4" fill="none"


### PR DESCRIPTION
Removing one space for the URL to work again.
Closes #122 .