### PR TITLE
Create ES5 / IE11 compatible webpack JS bundles.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const { SourceMapDevToolPlugin } = require("webpack");
 const path = require('path');
 
 module.exports = {
+  target: ["web", "es5"],
   entry: {
     datepicker: path.resolve(__dirname, 'src/plugins/datepicker.js'),
     flowbite: path.resolve(__dirname, 'src/flowbite.js'),


### PR DESCRIPTION
Fixes: #159

This is a small check to configure webpack to build the JS bundles for ES5 / IE11
 
Babel is already configured for IE11.

To test it run `build:webpack` and check that there are no arrow functions.
