### PR TITLE
Prevent anchor elements with empty fragments from linking to the top

### DIFF
--- a/src/docs.js
+++ b/src/docs.js
@@ -166,3 +166,10 @@ toggleSidebarMobileEl.addEventListener('click', () => {
 sidebarBackdrop.addEventListener('click', () => {
     toggleSidebarMobile(sidebar, sidebarBackdrop, toggleSidebarMobileHamburger, toggleSidebarMobileClose);
 });
+
+// Prevent anchor elements with empty fragments from linking to the top of the page 
+document.querySelectorAll('.code-example [href="#"]').forEach((event) => {
+    event.addEventListener('click', (event) => {
+        event.preventDefault();
+    })
+})


### PR DESCRIPTION
Anchor tags with `href="#"` in code examples will not scroll to the top of the page on click.