### PR TITLE
Add missing step in Rails getting started doc

### DIFF
--- a/content/getting-started/rails.md
+++ b/content/getting-started/rails.md
@@ -111,7 +111,13 @@ module.exports = {
 }
 ```
 
-10. Run the following command to include Flowbite's JavaScript inside the `importmap.rb` file:
+10. Add Flowbite's JavaScript in `app/javascript/application.js`:
+
+```javascript
+import "flowbite"
+```
+
+11. Run the following command to include Flowbite's JavaScript inside the `importmap.rb` file:
 
 ```bash
 ./bin/importmap pin flowbite


### PR DESCRIPTION
I just tried Flowbite this morning on a newly created Rails 7.0.3.1 project, following the instructions [here](https://flowbite.com/docs/getting-started/rails/). In the end the Javascript part wasn't included, hence the example tooltip wasn't working.

This PR fixes the doc so Flowbite Javascript code is included in your Rails application bundle. Note that it's just a cosmetic change and it does NOT solve the compatibility issue with Rails' Turbo, e.g. #88 