### PR TITLE
fix: typo in tabs component in Full width tabs

### DIFF
--- a/content/components/tabs.md
+++ b/content/components/tabs.md
@@ -130,9 +130,9 @@ If you want to show the tabs on the full width relative to the parent element yo
     <label for="tabs" class="sr-only">Select your country</label>
     <select id="tabs" class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
         <option>Profile</option>
-        <option>Canada</option>
-        <option>France</option>
-        <option>Germany</option>
+        <option>Dashboard</option>
+        <option>setting</option>
+        <option>Invoioce</option>
     </select>
 </div>
 <ul class="hidden text-sm font-medium text-center text-gray-500 rounded-lg divide-x divide-gray-200 shadow sm:flex dark:divide-gray-700 dark:text-gray-400">


### PR DESCRIPTION
remove the typo  in the tabs component with full-width tabs #261