### PR TITLE
modal component: improve backdrop, now associated with modal id

### DIFF
--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -22,7 +22,7 @@ class Modal {
     _createBackdrop() {
         if (this._isHidden) {
             const backdropEl = document.createElement('div');
-            backdropEl.setAttribute('modal-backdrop', '');
+            backdropEl.setAttribute('modal-backdrop', this._targetEl.id);
             backdropEl.classList.add(...this._options.backdropClasses.split(" "));
             document.querySelector('body').append(backdropEl);
         }
@@ -30,7 +30,7 @@ class Modal {
 
     _destroyBackdropEl() {
         if (!this._isHidden) {
-            document.querySelector('[modal-backdrop]').remove();
+            document.querySelector(`[modal-backdrop=${this._targetEl.id}]`).remove();
         }
     }
 

--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -30,7 +30,7 @@ class Modal {
 
     _destroyBackdropEl() {
         if (!this._isHidden) {
-            document.querySelector(`[modal-backdrop=${this._targetEl.id}]`).remove();
+            document.querySelector(`[modal-backdrop="${this._targetEl.id}"]`).remove();
         }
     }
 


### PR DESCRIPTION
I found this useful in case of stacked modal. Previously during backdrop remove, it only remove the first backdrop element. With my code, we ensure that every backdrop has association with the modal ID.