### PR TITLE
fix data-drawer-body-scrolling typo

### DIFF
--- a/content/components/drawer.md
+++ b/content/components/drawer.md
@@ -441,7 +441,7 @@ This is an example where the body scrolling behaviour is disabled when the drawe
 
 ### Enabled
 
-Get started with this example in order to enable body scrolling even if the drawer component is visible by using the `data-drawer-body-scrolling="false"` data attribute.
+Get started with this example in order to enable body scrolling even if the drawer component is visible by using the `data-drawer-body-scrolling="true"` data attribute.
 
 {{< example id="drawer-body-scrolling-example" github="components/drawer.md" show_dark=true iframeHeight="640" iframeMaxHeight="640" iframeMaxHeight="640" skeletonPlaceholders=true >}}
 <!-- drawer init and toggle -->


### PR DESCRIPTION
While learning about the Drawer component, I noticed a typo in the documentation. This PR makes no behavioral changes.