### PR TITLE
Small typo fix in image caption tag

### DIFF
--- a/content/typography/images.md
+++ b/content/typography/images.md
@@ -79,7 +79,7 @@ Use this example to make the image a card item with a link and a short text desc
   </a>
   <figcaption class="absolute bottom-6 px-4 text-lg text-white">
       <p>Do you want to get notified when a new component is added to Flowbite?</p>
-  </figcatpion>
+  </figcaption>
 </figure>
 {{< /example >}}
 


### PR DESCRIPTION
Fixed an invalid tag ending in the documentation sample