### PR TITLE
docs: fix typo in modal.md

### DIFF
--- a/content/components/modal.md
+++ b/content/components/modal.md
@@ -28,7 +28,7 @@ If you want to toggle the visibility, show, or hide the modal you can use the fo
 
 {{< example id="default-modal-example" github="components/modal.md" class="flex justify-center" show_dark=true iframeHeight="500" >}}
 <!-- Modal toggle -->
-<button data-modal-target="default" data-modal-toggle="defaultModal" class="block text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" type="button">
+<button data-modal-target="defaultModal" data-modal-toggle="defaultModal" class="block text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" type="button">
   Toggle modal
 </button>
 


### PR DESCRIPTION
Changed default to defaultModal in the first example.