### PR TITLE
Add instructions for ESbuild on Rails Quick Start

### DIFF
--- a/content/getting-started/rails.md
+++ b/content/getting-started/rails.md
@@ -112,8 +112,9 @@ module.exports = {
 ```
 
 ### Turbo load support
+#### Importmap
 
-In order to support turbo load from Ruby on Rails 7 you have to pin the `flowbite.turbo.js` file from a CDN where the `turbo:load` event listeners are added instead of `load`.
+Importmap is the default way of handling JavaScript on Rails 7. In order to support turbo load from importmaps you have to pin the `flowbite.turbo.js` file from a CDN where the `turbo:load` event listeners are added instead of `load`.
 
 1. Add the following line inside your `importmap.rb` file:
 
@@ -128,6 +129,13 @@ import 'flowbite';
 ```
 
 This will enable the interactive elements like dropdowns, modals, and navbars work by hooking the event listeners and actions to the data attributes whenever a new page is loaded in your application.
+
+#### ESBuild
+If you use ESBuild to Bundle your JavaScript on Rails, you will need to import a version of Flowbite which supports the `turbo:load` event listeners instead of `load`. To do this **add the line below** to your `application.js` file:
+
+```javascript
+import "flowbite/dist/flowbite.turbo.js";
+```
 
 ### Standard JS (no turbo)
 


### PR DESCRIPTION
Importmaps are the default way to use JS with Rails, but some apps (including those that use React or existed prior to Rails 7) don't use them yet. ESBuild is a very popular tool amongst Rails developers, and I feel it'd be useful to add the instructions on the official docs.

Besides ESbuild, it'd be nice to add instructions for Webpacker and Rollup which are the other bundlers supported by [jsbundling-rails](https://github.com/rails/jsbundling-rails/), but I haven't worked with those gems yet...