### PR TITLE
Adds close tooltips with esc key to meet WCAG 

### DIFF
--- a/src/components/popover/index.ts
+++ b/src/components/popover/index.ts
@@ -22,6 +22,7 @@ class Popover implements PopoverInterface {
     _options: PopoverOptions;
     _popperInstance: PopperInstance;
     _clickOutsideEventListener: EventListenerOrEventListenerObject;
+    _keydownEventListener: EventListenerOrEventListenerObject;
     _visible: boolean;
 
     constructor(
@@ -111,6 +112,27 @@ class Popover implements PopoverInterface {
         }
     }
 
+    _setupKeydownListener() {
+        this._keydownEventListener = (ev: KeyboardEvent) => {
+            if (ev.key === 'Escape') {
+                this.hide();
+            }
+        };
+        document.body.addEventListener(
+            'keydown',
+            this._keydownEventListener,
+            true
+        );
+    }
+
+    _removeKeydownListener() {
+        document.body.removeEventListener(
+            'keydown',
+            this._keydownEventListener,
+            true
+        );
+    }
+
     _setupClickOutsideListener() {
         this._clickOutsideEventListener = (ev: MouseEvent) => {
             this._handleClickOutside(ev, this._targetEl);
@@ -171,6 +193,9 @@ class Popover implements PopoverInterface {
         // handle click outside
         this._setupClickOutsideListener();
 
+        // handle esc keydown
+        this._setupKeydownListener();
+
         // Update its position
         this._popperInstance.update();
 
@@ -196,6 +221,9 @@ class Popover implements PopoverInterface {
 
         // handle click outside
         this._removeClickOutsideListener();
+
+        // handle esc keydown
+        this._removeKeydownListener();
 
         // set visibility to false
         this._visible = false;

--- a/src/components/popover/interface.ts
+++ b/src/components/popover/interface.ts
@@ -11,10 +11,13 @@ export declare interface PopoverInterface {
     _options: PopoverOptions;
     _popperInstance: PopperInstance;
     _clickOutsideEventListener: EventListenerOrEventListenerObject;
+    _keydownEventListener: EventListenerOrEventListenerObject;
 
     _setupEventListeners(): void;
     _setupClickOutsideListener(): void;
     _removeClickOutsideListener(): void;
+    _setupKeydownListener(): void;
+    _removeKeydownListener(): void;
     _handleClickOutside(ev: Event, targetEl: HTMLElement): void;
     _getTriggerEvents(
         triggerType: PopoverTriggerType

--- a/src/components/tooltip/index.ts
+++ b/src/components/tooltip/index.ts
@@ -21,6 +21,7 @@ class Tooltip implements TooltipInterface {
     _options: TooltipOptions;
     _popperInstance: PopperInstance;
     _clickOutsideEventListener: EventListenerOrEventListenerObject;
+    _keydownEventListener: EventListenerOrEventListenerObject;
     _visible: boolean;
 
     constructor(
@@ -95,6 +96,27 @@ class Tooltip implements TooltipInterface {
         }
     }
 
+    _setupKeydownListener() {
+        this._keydownEventListener = (ev: KeyboardEvent) => {
+            if (ev.key === 'Escape') {
+                this.hide();
+            }
+        };
+        document.body.addEventListener(
+            'keydown',
+            this._keydownEventListener,
+            true
+        );
+    }
+
+    _removeKeydownListener() {
+        document.body.removeEventListener(
+            'keydown',
+            this._keydownEventListener,
+            true
+        );
+    }
+
     _setupClickOutsideListener() {
         this._clickOutsideEventListener = (ev: MouseEvent) => {
             this._handleClickOutside(ev, this._targetEl);
@@ -154,6 +176,9 @@ class Tooltip implements TooltipInterface {
         // handle click outside
         this._setupClickOutsideListener();
 
+        // handle esc keydown
+        this._setupKeydownListener();
+
         // Update its position
         this._popperInstance.update();
 
@@ -179,6 +204,9 @@ class Tooltip implements TooltipInterface {
 
         // handle click outside
         this._removeClickOutsideListener();
+
+        // handle esc keydown
+        this._removeKeydownListener();
 
         // set visibility
         this._visible = false;

--- a/src/components/tooltip/interface.ts
+++ b/src/components/tooltip/interface.ts
@@ -11,11 +11,14 @@ export declare interface TooltipInterface {
     _options: TooltipOptions;
     _popperInstance: PopperInstance;
     _clickOutsideEventListener: EventListenerOrEventListenerObject;
+    _keydownEventListener: EventListenerOrEventListenerObject;
 
     _init(): void;
     _setupEventListeners(): void;
     _setupClickOutsideListener(): void;
     _removeClickOutsideListener(): void;
+    _setupKeydownListener(): void;
+    _removeKeydownListener(): void;
     _handleClickOutside(ev: Event, targetEl: HTMLElement): void;
     _getTriggerEvents(
         triggerType: TooltipTriggerType


### PR DESCRIPTION
We are currently undergoing a WCAG audit on our site and reskinning it with flowbite. We were penalised for not having our tooltips close with the escape key and I noticed that the flowbite tooltips also behave the same. I have used the modal esc key event listeners, modified them slightly and bought them into here. 

Please let me know if you think this is a suitable solutons.

Loving flowbite, thanks for all the hard work!

https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/