### PR TITLE
Flowbite with Turbo when render event is fired

### DIFF
--- a/src/index.turbo.ts
+++ b/src/index.turbo.ts
@@ -12,7 +12,7 @@ import Tabs, { initTabs } from './components/tabs';
 import Tooltip, { initTooltips } from './components/tooltip';
 import Events from './dom/events';
 
-const events = new Events('turbo:load', [
+const events = new Events('turbo:render', [
     initAccordions,
     initCollapses,
     initCarousels,


### PR DESCRIPTION
I had a problem with Tabs when the rails form threw an error, the `turbo:load` event was not fired when an error occurred, but the `turbo:render` event was. So, maybe it would be better to replace the `turbo:load` event with turbo:render, and to make it work with frames make a listener for `turbo:frame-render `as well.