### PR TITLE
Include plugin-windicss.js on npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   "files": [
     "lib",
     "dist",
-    "plugin.js"
+    "plugin.js",
+    "plugin-windicss.js"
   ]
 }


### PR DESCRIPTION
Following the guide on https://flowbite.com/docs/getting-started/introduction/#windicss, the code provided will throw
`Error: Cannot find module 'flowbite/plugin-windicss'` and will not work since `plugin-windicss.js` is not included in the npm package.