### PR TITLE
Add type declaration for Tailwind plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   "files": [
     "lib",
     "dist",
+    "plugin.d.ts",
     "plugin.js",
     "plugin-windicss.js"
   ]

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,0 +1,2 @@
+declare const plugin: { handler: () => void }
+export = plugin


### PR DESCRIPTION
TailwindCSS 3.3 supports configs in Typescript.

Importing Flowbite in Tailwind-config written in TS results in a 'Could not find declaration file for module'-error.

This PR adds a basic type declaration for the plugin so that it can be imported without errors.