### PR TITLE
fix(nuxt-js): fix getting-started tailwind config

### DIFF
--- a/content/getting-started/nuxt-js.md
+++ b/content/getting-started/nuxt-js.md
@@ -113,7 +113,7 @@ npm install flowbite
 module.exports = {
   // other options ...
   plugins: [
-    require('flowbite')
+    require('flowbite/plugin')
   ],
 }
 ```


### PR DESCRIPTION
Hi, 

A small issue on the Nuxt "getting started" documentation. 

It is mentioned that you should add in the Tailwind config file this plugin : 
`require('flowbite')`

When you should actually put : 
`require('flowbite/plugin')`

I've lost countless hours on this... found the issue... This PR fixes it ^^

Maxime.