### PR TITLE
Improved astro documentations

### DIFF
--- a/content/getting-started/astro.md
+++ b/content/getting-started/astro.md
@@ -98,10 +98,21 @@ To enable the interactive components you need to also include Flowbite's JavaScr
 
 ### Include via CDN
 
-In the `Layout.astro` file add the following script tag just before the end of the `<body>` tag:
+In the `Layout.astro` file import flowbite in the html part of the component
 
 ```html
-<script is:inline src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.5/flowbite.min.js"></script>
+---
+// component js
+...
+---
+
+<html>
+...
+</html>
+
+<script>
+    import "flowbite";
+</script>
 ```
 
 This allows you to use the data attributes from the Flowbite component examples and will make them interactive automatically without needing to write custom JavaScript and you can just copy-paste them from the Flowbite Docs.


### PR DESCRIPTION
Removed the direct reference to the flowbite script so that it uses the import statement.

As seen in #544 