### PR TITLE
Fixed carousel not working when only one item, mentionned in #175

### DIFF
--- a/src/components/carousel/index.ts
+++ b/src/components/carousel/index.ts
@@ -154,6 +154,19 @@ class Carousel implements CarouselInterface {
             item.el.classList.add('hidden');
         });
 
+        // Handling the case when there is only one item
+        if (this._items.length === 1) {
+            rotationItems.middle.el.classList.remove(
+                '-translate-x-full',
+                'translate-x-full',
+                'translate-x-0',
+                'hidden',
+                'z-10'
+            );
+            rotationItems.middle.el.classList.add('translate-x-0', 'z-20');
+            return;
+        }
+
         // left item (previously active)
         rotationItems.left.el.classList.remove(
             '-translate-x-full',


### PR DESCRIPTION
I encountered an issue with the Carousel component that was mentionned in this issue #175. When there is only one item in the carousel, it's not visible even if `data-carousel-item` is set to `active`. 

I've added a manual check in _rotate to handle the case when there is only one item. I'm really not sure if that was the best way to fix the issue, but it worked for me. 

Changes:
- Update `_rotate` function to handle the case when there's only one item in the carousel
