### PR TITLE
Fix line through example on dark theme

### DIFF
--- a/content/typography/text.md
+++ b/content/typography/text.md
@@ -91,7 +91,7 @@ Underline text by using the `underline` class or disable it using `no-underline`
 Set a strikethrough line on a text element using the `line-through` class.
 
 {{< example id="text-line-through-example" github="typography/text.md" show_dark=true >}}
-<span class="text-lg font-medium text-gray-900 line-through dark:text-white">$109</span><span class="ml-3 text-lg font-medium">$79</span>
+<span class="text-lg font-medium text-gray-900 line-through dark:text-white">$109</span><span class="ml-3 text-lg font-medium text-gray-900 dark:text-white">$79</span>
 {{< /example >}}
 
 ### Uppercase


### PR DESCRIPTION
In the line through example, the text color wasn't right on dark themes

**Before :**
![image](https://github.com/themesberg/flowbite/assets/2933420/b45bdb6a-2407-484c-8d1e-8ff55495b6df)

**After :**
![image](https://github.com/themesberg/flowbite/assets/2933420/d07a390c-32dc-432f-9796-5cb5dd459f40)
