### PR TITLE
Fix checkbox indeterminate icon

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -345,7 +345,7 @@ module.exports = plugin.withOptions(
                     [`[type='checkbox']:indeterminate`]: {
                         'background-image': `url("${svgToDataUri(
                             `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 12">
-                            <path stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M1 5.917 5.724 10.5 15 1.5"/>
+                            <path stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M0.5 6h14"/>
                             </svg>`
                         )}")`,
                         'background-color': `currentColor`,


### PR DESCRIPTION
This merged PR https://github.com/themesberg/flowbite/pull/588 changed the checkbox indeterminate icon. Now, it no longer looks like it should be, it looks like it's checked, not indeterminate. This PR fixes that.

**Before:**
![checkbox-indeterminate-before](https://github.com/themesberg/flowbite/assets/20999009/137c7b87-0b75-4da4-be49-b18cb422d84f)

**After:**
![checkbox-indeterminate-after](https://github.com/themesberg/flowbite/assets/20999009/80ec45be-1a6c-4eaf-875d-e7d18a18a992)
