### PR TITLE
Adds import directive in documentation for datepicker+turbo

### DIFF
--- a/content/getting-started/rails.md
+++ b/content/getting-started/rails.md
@@ -182,6 +182,7 @@ Don't forget to also import it inside your `application.js` file:
 
 ```javascript
 import 'flowbite-datepicker';
+import 'flowbite/dist/datepicker.turbo.js';
 ```
 
 ## Building your project

--- a/content/plugins/datepicker.md
+++ b/content/plugins/datepicker.md
@@ -220,4 +220,5 @@ Don't forget to also import it inside your `application.js` file:
 
 ```javascript
 import 'flowbite-datepicker';
+import 'flowbite/dist/datepicker.turbo.js';
 ```


### PR DESCRIPTION
* Adds copy/paste friendly import directive for instantiating the datepicker on turbo load
* I had found the documentation a bit confusing since the sentence that mentioned turbo support only said `datepicker.turbo.js` but did not include the complete path to the file