### PR TITLE
fix: switch direction of accordion arrows to point properly 

### DIFF
--- a/src/components/accordion/index.ts
+++ b/src/components/accordion/index.ts
@@ -97,7 +97,7 @@ class Accordion implements AccordionInterface {
 
                     // rotate icon if set
                     if (i.iconEl) {
-                        i.iconEl.classList.remove('rotate-180');
+                        i.iconEl.classList.add('rotate-180');
                     }
                 }
             });
@@ -114,7 +114,7 @@ class Accordion implements AccordionInterface {
 
         // rotate icon if set
         if (item.iconEl) {
-            item.iconEl.classList.add('rotate-180');
+            item.iconEl.classList.remove('rotate-180');
         }
 
         // callback function
@@ -149,7 +149,7 @@ class Accordion implements AccordionInterface {
 
         // rotate icon if set
         if (item.iconEl) {
-            item.iconEl.classList.remove('rotate-180');
+            item.iconEl.classList.add('rotate-180');
         }
 
         // callback function


### PR DESCRIPTION
Fix direction of accordion arrows which are currently pointing in the wrong direction when  in the open and closed state. Switched instances of  ``` i.iconEl.classList.add('rotate-180')```  to ``` i.iconEl.classList.remove('rotate-180')```  and vice versa in accordion index.ts

Fixes #703 
