### PR TITLE
:zap: Add '/lib' to narrow flowbite config #743

### DIFF
--- a/content/getting-started/next-js.md
+++ b/content/getting-started/next-js.md
@@ -131,7 +131,7 @@ module.exports = {
  */
 module.exports = {
   content: [
-    "./node_modules/flowbite-react/**/*.js",
+    "./node_modules/flowbite-react/lib/**/*.js",
     "./pages/**/*.{ts,tsx}",
     "./public/**/*.html",
   ],


### PR DESCRIPTION
Presently compilation takes ~90s if you follow the NextJS [guide](https://flowbite.com/docs/getting-started/next-js/).  Narrowing the scope of the tailwind config content for flowbite to the /lib folder reduces it to ~5.