### PR TITLE
Replaced text-md with text-base in forms and input-field docs

### DIFF
--- a/content/components/forms.md
+++ b/content/components/forms.md
@@ -94,7 +94,7 @@ Use the following utility classes to create three different sizing options (larg
 <form class="max-w-sm mx-auto">
   <div class="mb-5">
       <label for="large-input" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Large input</label>
-      <input type="text" id="large-input" class="block w-full p-4 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+      <input type="text" id="large-input" class="block w-full p-4 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-base focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
   </div>
   <div class="mb-5">
       <label for="base-input" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Base input</label>

--- a/content/forms/input-field.md
+++ b/content/forms/input-field.md
@@ -76,7 +76,7 @@ Use the following examples to apply a small, default or large size for the input
 {{< example id="input-field-sizes-example" github="forms/input-field.md" show_dark=true >}}
 <div class="mb-6">
     <label for="large-input" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Large input</label>
-    <input type="text" id="large-input" class="block w-full p-4 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+    <input type="text" id="large-input" class="block w-full p-4 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-base focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
 </div>
 <div class="mb-6">
     <label for="default-input" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Default input</label>


### PR DESCRIPTION
I replaced the utility class text-md in the input-field docs and forms docs, because it does not (or maybe never) exist anymore.