### PR TITLE
Add extra check when removing drawer backdrop

### DIFF
--- a/src/components/drawer/index.ts
+++ b/src/components/drawer/index.ts
@@ -217,7 +217,7 @@ class Drawer implements DrawerInterface {
     }
 
     _destroyBackdropEl() {
-        if (this._visible) {
+        if (this._visible && document.querySelector('[drawer-backdrop]') !== null) {
             document.querySelector('[drawer-backdrop]').remove();
         }
     }


### PR DESCRIPTION
This fixes the issue of the drawer breaking when using turbo:
![image](https://github.com/themesberg/flowbite/assets/2458807/d183841f-ae36-4bf9-bed0-b8de4f2c4609)

![image](https://github.com/themesberg/flowbite/assets/2458807/6705ad15-8ed2-485a-b5c7-2edf83192a59)