### PR TITLE
Add missing fenced code blocks in the dropdown docs

### DIFF
--- a/content/components/dropdowns.md
+++ b/content/components/dropdowns.md
@@ -1595,28 +1595,71 @@ dropdown.isVisible();
 
 Use the following HTML code for the JavaScript example above.
 
-<button id="dropdownButton" data-dropdown-toggle="dropdown" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" type="button">Dropdown button <svg class="w-2.5 h-2.5 ms-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-</svg>
+```html
+<button
+	id="dropdownButton"
+	data-dropdown-toggle="dropdown"
+	class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+	type="button"
+>
+	Dropdown button
+	<svg
+		class="w-2.5 h-2.5 ms-3"
+		aria-hidden="true"
+		xmlns="http://www.w3.org/2000/svg"
+		fill="none"
+		viewBox="0 0 10 6"
+	>
+		<path
+			stroke="currentColor"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+			d="m1 1 4 4 4-4"
+		/>
+	</svg>
 </button>
 
 <!-- Dropdown menu -->
-<div id="dropdownMenu" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700">
-    <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownButton">
-      <li>
-        <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">Dashboard</a>
-      </li>
-      <li>
-        <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">Settings</a>
-      </li>
-      <li>
-        <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">Earnings</a>
-      </li>
-      <li>
-        <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">Sign out</a>
-      </li>
-    </ul>
+<div
+	id="dropdownMenu"
+	class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700"
+>
+	<ul
+		class="py-2 text-sm text-gray-700 dark:text-gray-200"
+		aria-labelledby="dropdownButton"
+	>
+		<li>
+			<a
+				href="#"
+				class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+				>Dashboard</a
+			>
+		</li>
+		<li>
+			<a
+				href="#"
+				class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+				>Settings</a
+			>
+		</li>
+		<li>
+			<a
+				href="#"
+				class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+				>Earnings</a
+			>
+		</li>
+		<li>
+			<a
+				href="#"
+				class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+				>Sign out</a
+			>
+		</li>
+	</ul>
 </div>
+```
 
 ### TypeScript
 


### PR DESCRIPTION
**Problem**
In the dropdown documentation page, under `Javascript Behaviour > HTML Markup`, a dropdown element is displayed, where it says "Use the following _HTML code_...".

**Screenshot**
![image](https://github.com/themesberg/flowbite/assets/50076340/734d42f2-58ce-44d8-9d20-362b3819a543)

**Expected Result**
It should display the HTML code of the dropdown, instead of the actual visual representation of the dropdown.

**Solution**
Add fenced code blocks (```) to display the output correctly.

**Note:** The HTML code is formatted with prettier. Let me know if the expectation is the default formatting.

@zoltanszogyenyi Please review.