### PR TITLE
Add missing argument description in the docs for tabs

### DIFF
--- a/content/components/tabs.md
+++ b/content/components/tabs.md
@@ -525,9 +525,10 @@ Create a new Tabs object based on the parameters we've previously set.
 import { Tabs } from 'flowbite';
 
 /*
-* tabElements: array of tab objects
-* options: optional
-* instanceOptions: optional
+* tabsElement: parent element of the tabs component (required)
+* tabElements: array of tab objects (required)
+* options (optional)
+* instanceOptions (optional)
 */
 const tabs = new Tabs(tabsElement, tabElements, options, instanceOptions);
 ```
@@ -722,8 +723,10 @@ const instanceOptions: InstanceOptions = {
 };
 
 /*
-* tabElements: array of tab objects
-* options: optional
+* tabsElement: parent element of the tabs component (required)
+* tabElements: array of tab elements (required)
+* options (optional)
+* instanceOptions (optional)
 */
 const tabs: TabsInterface = new Tabs(tabsElement, tabElements, options, instanceOptions);
 


### PR DESCRIPTION
**Problem**
In the tabs documentation page, under `Javascript behaviour > Example` and `Javascript behaviour > TypeScript`, the comments for creating a new Tabs object does not match the comments.

**Screenshot**
![image](https://github.com/themesberg/flowbite/assets/50076340/6b228599-94b0-489f-a693-4e225c436c41)

**Expected Result**
It should display the arguments in the comments with it's meaning and optionality respectively.

**Solution**
Fix the missing comments similar to other pages.

@zoltanszogyenyi Please review.