### PR TITLE
Add and update group names in the content files

### DIFF
--- a/content/customize/rtl.md
+++ b/content/customize/rtl.md
@@ -2,6 +2,7 @@
 layout: home
 title: Tailwind CSS RTL (Right-To-Left) - Flowbite
 description: Learn how to setup and configure bidirectional text formats (RTL and LTR) in your project using native Tailwind CSS variants and the Flowbite UI components
+group: customize
 toc: true
 
 previous: Icons

--- a/content/forms/number-input.md
+++ b/content/forms/number-input.md
@@ -2,7 +2,7 @@
 layout: home
 title: Tailwind CSS Number Input - Flowbite
 description: Use the number input component to set a numeric value inside a form field based on multiple styles, variants, and layouts that can be used in product pages, forms, and more
-group: components
+group: forms
 requires_js: true
 toc: true
 

--- a/content/forms/phone-input.md
+++ b/content/forms/phone-input.md
@@ -2,7 +2,7 @@
 layout: home
 title: Tailwind CSS Phone Input - Flowbite
 description: Use the phone number input component from Flowbite to set a phone number inside a form field and use a dropdown menu to select the country code based on various styles, sizes and colors
-group: components
+group: forms
 requires_js: true
 toc: true
 


### PR DESCRIPTION
**Problem**
In the sidebar, going to the `RTL`, `Number Input` and `Search Input`, the pages wouldn't turn blue (referring to current page).

**Screenshots**
1. Page URL
![image](https://github.com/themesberg/flowbite/assets/50076340/70827736-d945-45e9-b97a-b4d330f293f5)
3. Sidebar
![image](https://github.com/themesberg/flowbite/assets/50076340/9be3bd2f-f26f-4f7c-8f60-89766392fc92)

**Expected Result**
The page names should be `blue` when the page name matches the route. 

**Solution**
Add and update the group names in the content files as follows:
1. The RTL page should have `group` param with `customize`.
2. The Number Input and Search Input pages should have `forms` instead of `components`.

@zoltanszogyenyi Please review.


