### PR TITLE
Call preventDefault for anchor based tab toggles

### DIFF
--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -60,7 +60,8 @@ class Tabs implements TabsInterface {
 
             // show tab content based on click
             this._items.map((tab) => {
-                tab.triggerEl.addEventListener('click', () => {
+                tab.triggerEl.addEventListener('click', (event) => {
+                    event.preventDefault();
                     this.show(tab.id);
                 });
             });


### PR DESCRIPTION
This is needed for the anchor based examples to prevent the `#` being appended to the browser URL and to keep the page scroll position, otherwise it jumps to the top. This won't conflict with the button based approach for tab toggles.