### PR TITLE
 Fix typos in tooltips.md and javascript.md

### DIFF
--- a/content/components/tooltips.md
+++ b/content/components/tooltips.md
@@ -57,7 +57,7 @@ You can use choose between dark and light version styles for the tooltip compone
 
 ## Placement
 
-The positioning of the tooltip element relative to the triggering element (eg. button, link) can be set using the `data-tooltip-placement="{top|right|bottom"left}"` data attribute.
+The positioning of the tooltip element relative to the triggering element (eg. button, link) can be set using the `data-tooltip-placement="{top|right|bottom|left}"` data attribute.
 
 {{< example id="tooltip-placement-example" class="flex flex-wrap justify-center py-8" github="components/tooltips.md" show_dark=true >}}
 

--- a/content/getting-started/javascript.md
+++ b/content/getting-started/javascript.md
@@ -284,7 +284,7 @@ FlowbiteInstances.getAllInstances();
 Alternatively, you can also get all of the instances from one component pool such as from the modals:
 
 ```javascript
-FlowbiteInstance.getInstances('Modal');
+FlowbiteInstances.getInstances('Modal');
 ```
 
 ## Instance options


### PR DESCRIPTION
typo in the Placement section of Tooltip component:
`data-tooltip-placement="{top|right|bottom"left}"`  should be `data-tooltip-placement="{top|right|bottom|left}"`

See: https://github.com/themesberg/flowbite/issues/816#issue-2152773500

---

and also typo in end of [Instance manager](https://flowbite.com/docs/getting-started/javascript/#instance-manager)
`FlowbiteInstance.getInstances('Modal');` should be `FlowbiteInstances.getInstances('Modal');`