### PR TITLE
Fix overflow issue when using Tooltip/Popover

### DIFF
--- a/src/components/popover/index.ts
+++ b/src/components/popover/index.ts
@@ -121,7 +121,9 @@ class Popover implements PopoverInterface {
                 }
             }, 100);
             setTimeout(() => {
-                this._targetEl.style.transform ='';
+                if (!this._targetEl.matches(':hover')) {
+                    this._targetEl.style.transform ='';
+                }
             }, 100);
         };
 

--- a/src/components/popover/index.ts
+++ b/src/components/popover/index.ts
@@ -120,6 +120,9 @@ class Popover implements PopoverInterface {
                     this.hide();
                 }
             }, 100);
+            setTimeout(() => {
+                this._targetEl.style.transform ='';
+            }, 100);
         };
 
         triggerEvents.showEvents.forEach((ev) => {

--- a/src/components/tooltip/index.ts
+++ b/src/components/tooltip/index.ts
@@ -112,6 +112,9 @@ class Tooltip implements TooltipInterface {
 
         this._hideHandler = () => {
             this.hide();
+            setTimeout(() => {
+                this._targetEl.style.transform ='';
+            }, 100);
         };
 
         triggerEvents.showEvents.forEach((ev) => {

--- a/src/components/tooltip/index.ts
+++ b/src/components/tooltip/index.ts
@@ -113,7 +113,9 @@ class Tooltip implements TooltipInterface {
         this._hideHandler = () => {
             this.hide();
             setTimeout(() => {
-                this._targetEl.style.transform ='';
+                if (!this._targetEl.matches('.opacity-100.visible')) {
+                    this._targetEl.style.transform ='';
+                }
             }, 100);
         };
 


### PR DESCRIPTION
Fix #854 

Strictly speaking, this issue is due to the use of popperjs in flowbite, but it can be fixed from the flowbite side