### PR TITLE
fix: screen image rounding on laptop mockup

### DIFF
--- a/content/components/device-mockups.md
+++ b/content/components/device-mockups.md
@@ -93,7 +93,7 @@ This example can be used to show a screenshot of your application inside a lapto
 {{< example id="laptop-mockup" github="components/device-mockups.md" show_dark=true >}}
 <div class="relative mx-auto border-gray-800 dark:border-gray-800 bg-gray-800 border-[8px] rounded-t-xl h-[172px] max-w-[301px] md:h-[294px] md:max-w-[512px]">
     <div class="rounded-lg overflow-hidden h-[156px] md:h-[278px] bg-white dark:bg-gray-800">
-        <img src="https://flowbite.s3.amazonaws.com/docs/device-mockups/laptop-screen.png" class="dark:hidden h-[156px] md:h-[278px] w-full rounded-xl" alt="">
+        <img src="https://flowbite.s3.amazonaws.com/docs/device-mockups/laptop-screen.png" class="dark:hidden h-[156px] md:h-[278px] w-full rounded-lg" alt="">
         <img src="https://flowbite.s3.amazonaws.com/docs/device-mockups/laptop-screen-dark.png" class="hidden dark:block h-[156px] md:h-[278px] w-full rounded-lg" alt="">
     </div>
 </div>


### PR DESCRIPTION
Properly aligns screen image to screen shape in light-mode.
This change also brings light-mode styling into line with dark mode styling for this element.

The misalignment becomes visible when an image with a darker image is used.

**Current implementation** has a dark image showing white in the corners.
<img width="500" alt="Before" src="https://github.com/themesberg/flowbite/assets/12572151/bcbbabd3-dece-40ae-9a2c-883078203c4b">

**With change**
<img width="500" alt="After" src="https://github.com/themesberg/flowbite/assets/12572151/1ece07ec-b133-4614-9787-82839e222662">

(Photo by <a href="https://unsplash.com/@instagramfotografin?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">[Peggy Anke](https://unsplash.com/@instagramfotografin?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash)</a> on <a href="https://unsplash.com/photos/woman-sitting-on-tiki-bar-facing-silver-laptop-Wu2MXvbyt7w?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">[Unsplash](https://unsplash.com/photos/woman-sitting-on-tiki-bar-facing-silver-laptop-Wu2MXvbyt7w?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash)</a>)