### PR TITLE
Update file-input.md

### DIFF
--- a/content/forms/file-input.md
+++ b/content/forms/file-input.md
@@ -65,7 +65,7 @@ The dropzone file input component can be used to upload one or more files by cli
 
 {{< example id="file-upload-dropzone-example" github="forms/file-input.md" show_dark=true >}}
 <div class="flex items-center justify-center w-full">
-    <label for="dropzone-file" class="flex flex-col items-center justify-center w-full h-64 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 dark:hover:bg-bray-800 dark:bg-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-600">
+    <label for="dropzone-file" class="flex flex-col items-center justify-center w-full h-64 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-800 hover:bg-gray-100 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-600">
         <div class="flex flex-col items-center justify-center pt-5 pb-6">
             <svg class="w-8 h-8 mb-4 text-gray-500 dark:text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 16">
                 <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 13h3a3 3 0 0 0 0-6h-.025A5.56 5.56 0 0 0 16 6.5 5.5 5.5 0 0 0 5.207 5.021C5.137 5.017 5.071 5 5 5a4 4 0 0 0 0 8h2.167M10 15V6m0 0L8 8m2-2 2 2"/>


### PR DESCRIPTION
Fix typo found in https://github.com/themesberg/flowbite/issues/882

But 

dark:hover:bg-bray-800 -> dark:hover:bg-gray-700
dark:bg-gray-700 -> dark:bg-gray-800

Looks like it should be brighter when you hover on it in dark mode. Please correct me if I'm wrong.