### PR TITLE
Update next-js.md: lib directory doesn't exist in node_modules/flowbi…

### DIFF
--- a/content/getting-started/next-js.md
+++ b/content/getting-started/next-js.md
@@ -131,7 +131,7 @@ module.exports = {
  */
 module.exports = {
   content: [
-    "./node_modules/flowbite-react/lib/**/*.js",
+    "./node_modules/flowbite-react/**/*.js",
     "./pages/**/*.{ts,tsx}",
     "./public/**/*.html",
   ],


### PR DESCRIPTION
./node_modules/flowbite-react/lib/**/*.js doesn't exist because there is no 'lib' dir in node_modules/flowbite-react
the  correct one would be ./node_modules/flowbite-react/**/*.js