### PR TITLE
Update index.turbo.ts

### DIFF
--- a/src/index.turbo.ts
+++ b/src/index.turbo.ts
@@ -24,7 +24,7 @@ addEventListener('turbo:before-stream-render', (event: CustomEvent) => {
 
     event.detail.render = function (streamElement: Element) {
         originalRender(streamElement);
-        document.dispatchEvent(afterRenderEvent);
+        window.dispatchEvent(afterRenderEvent);
     };
 });
 


### PR DESCRIPTION
When a Turbo-Stream response is returned by Rails server the library intercepts before-render and fires a custom event after-render which calls initFlowbite. However, the before-render event handler dispatches the Event on the document rather than window where the after-render handler was defined. So the after-render handler never gets called.

This PR dispatches the Event on window where the after-render handler was defined.