### PR TITLE
Dont set aria hidden on large viewports

### DIFF
--- a/src/components/drawer/index.ts
+++ b/src/components/drawer/index.ts
@@ -55,7 +55,9 @@ class Drawer implements DrawerInterface {
     init() {
         // set initial accessibility attributes
         if (this._targetEl && !this._initialized) {
-            this._targetEl.setAttribute('aria-hidden', 'true');
+            if (this.isHidden()) {
+                this._targetEl.setAttribute('aria-hidden', 'true');
+            }
             this._targetEl.classList.add('transition-transform');
 
             // set base placement classes

--- a/src/components/drawer/index.ts
+++ b/src/components/drawer/index.ts
@@ -41,7 +41,11 @@ class Drawer implements DrawerInterface {
             : targetEl.id;
         this._targetEl = targetEl;
         this._options = { ...Default, ...options };
-        this._visible = false;
+
+
+        const smallViewportSize = getComputedStyle(document.body).getPropertyValue('--small-viewport') || '640px';
+        this._visible = !window.matchMedia(`(max-width: ${smallViewportSize})`).matches;
+
         this._initialized = false;
         this.init();
         instances.addInstance(


### PR DESCRIPTION
Hello 👋🏻 

We're hitting this snag in our app where the sidebar is set with `[aria-hidden="true"]` when initialized. Apart from being a pretty serious accessibility issue it's also erroring in some cases for us in Chrome with the following in error:

![A Chrome error that reads: 'Blocked aria-hidden on a <a>
about: srcdoc: 1
element because the element that just received focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at
https://w3c.github.io/aria/#aria-hidden.
• <a href="#" class="flex items-center p-2 tex t-base font-medium text-gray-900 rounded-lg dark: text-white hover:bg-gray-100 dark:hove
r: bg-gray-700 group">
</a>'](https://github.com/user-attachments/assets/577de043-ff27-4380-a6a8-b4b06a7fe34e)

It looks like the sidebar is always initialized as hidden which does make sense in the context of a smaller viewport as it should render hidden and then toggled on and off. It makes less sense on larger viewports where we expect the sidebar to be rendered initially and then optionally users should be able to hide it.

This PR checks to see if we are rendering initially on a small viewport (640px or less) and sets the visibility state accordingly. I also made sure to read the CSS variable `--small-viewport` so that this size can be changed. I'm not sure if that's the way we'd like to do this. I thought there might be a specific Tailwind variable but didn't find one. We could also read this value from a data attribute if that makes more sense? It would mean that we'd be less likely to clash with a CSS variable set by apps.

Let me know what you think :)