### PR TITLE
fix react based docs

### DIFF
--- a/content/getting-started/next-js.md
+++ b/content/getting-started/next-js.md
@@ -219,3 +219,7 @@ The open-source community from Flowbite has created a few starter templates that
 
 - [Starter template on GitHub](https://github.com/themesberg/flowbite-react-template-nextjs)
 - [Starter template on StackBlitz](https://stackblitz.com/edit/flowbite-react-template-nextjs)
+
+## More examples
+
+You can additionally check out the [pro version of Flowbite](https://flowbite.com/pro/) to get access to over 300+ blocks, templates and an admin dashboard coded with Flowbite React and Tailwind CSS.

--- a/content/getting-started/next-js.md
+++ b/content/getting-started/next-js.md
@@ -16,32 +16,36 @@ nextLink: getting-started/vue/
 
 This technology is being used by hundreds of thousands of developers and companies such as Vercel, Netflix, TikTok, Twitch, Hulu, Nike and HBO Max since its original release in 2016.
 
-By following this guide you will learn how to properly set up [Tailwind CSS](https://tailwindcss.com/) with the [Flowbite React](https://flowbite-react.com/) components inside an existing or new [Next.js](https://nextjs.org/) project.
+By following this guide you will learn how to properly set up Tailwind CSS with the [Flowbite React](https://flowbite-react.com/) components inside an existing or new Next.js project.
 
 ## Requirements
 
-Make sure that you have [Node.js](https://nodejs.org/en/) installed on your computer to be able to install [Next.js](https://nextjs.org/), [Tailwind CSS](https://tailwindcss.com/) and [Flowbite React](https://flowbite-react.com/) using `npx` and `npm` commands.
+Make sure that you have [Node.js](https://nodejs.org/en/) installed on your computer to be able to install Next.js, Tailwind CSS and Flowbite React using `npx` and `npm` commands.
 
 ## Create a Next.js project
 
+Follow the next steps to create a brand new Next.js project using the CLI or a manual installation.
+
 ### Using the CLI
 
-Run the following command to scaffold a new [Flowbite React](https://flowbite-react.com/) project using [Next.js](https://nextjs.org/):
+Run the following command to scaffold a new Flowbite React project using Next.js:
 
 ```bash
 npm create flowbite-react@latest -- --template nextjs
 ```
 
+Running this will automatically set up Flowbite React in a Next.js project environment.
+
 ### Manual install
 
-1. Run the following command to create a new starter [Next.js](https://nextjs.org/) project:
+1. Run the following command to create a new starter Next.js project:
 
 ```bash
 npx create-next-app@latest
 cd my-app
 ```
 
-This command will install all of the necessary dependencies and boilerplate files for a basic [Next.js](https://nextjs.org/) project.
+This command will install all of the necessary dependencies and boilerplate files for a basic Next.js project.
 
 2. Run the following command in your terminal to start a local server:
 
@@ -57,17 +61,19 @@ This will make local development accessible via the browser on `http://localhost
 npm run build
 ```
 
+Now that you have created a Next.js project you can proceed by setting up Tailwind CSS.
+
 ## Install Tailwind CSS
 
-After you have a working Next.js project the next step would be to follow the [installation guide](https://tailwindcss.com/docs/guides/nextjs) for Tailwind CSS.
+Follow the next steps to set up Tailwind CSS inside your Next.js project.
 
-1. Install Tailwind CSS, PostCSS and Autoprefixer using NPM:
+1. Run the following command to install Tailwind CSS, Post CSS and Autoprefixer:
 
 ```bash
 npm install -D tailwindcss postcss autoprefixer
 ```
 
-2. Create a new `tailwind.config.js` and `postcss.config.js` file by running the following command in your terminal:
+2. Create a new `tailwind.config.js` and `postcss.config.js` file by running the following command:
 
 ```bash
 npx tailwindcss init -p
@@ -95,7 +101,7 @@ module.exports = {
 };
 ```
 
-This is needed in order to look for all of the class names inside the project and only include the used ones in the final CSS file.
+This is needed for tagging all class names inside the project and including only the used ones in the CSS file.
 
 4. Replace the contents of the `styles/globals.css` file and import the following directives:
 
@@ -111,15 +117,15 @@ Follow the steps of the next section in this tutorial to start using a library o
 
 ## Install Flowbite React
 
-[Flowbite React](https://github.com/themesberg/flowbite-react) is an open-source set of interactive React components based on the Tailwind CSS utility-first framework featuring interactive elements such as modals, navbars, dropdowns, carousels, and more.
+Flowbite React is an open-source set of interactive React components based on the Tailwind CSS utility-first framework featuring interactive elements such as modals, navbars, dropdowns, carousels, and more.
 
-1. Install [Flowbite React](https://flowbite-react.com/) via NPM by running the following command:
+1. Install Flowbite React  via NPM by running the following command:
 
 ```bash
 npm install flowbite-react
 ```
 
-2. Import [Flowbite React](https://flowbite-react.com/) and add the `plugin` and the `content` path inside your `tailwind.config.js` file:
+2. Import Flowbite React  and add the `plugin` and the `content` path inside your `tailwind.config.js` file:
 
 ```javascript
 const flowbite = require("flowbite-react/tailwind");
@@ -137,13 +143,11 @@ module.exports = {
 };
 ```
 
-Now that you have successfully installed [Flowbite React](https://flowbite-react.com/) you can start using the components from the library.
+Now that you have successfully installed Flowbite React  you can start using the components from the library.
 
 ## Flowbite components
 
-To get you started you can check out the full collection of React components from the [Flowbite React repository](https://github.com/themesberg/flowbite-react) and browse the documentation for the source code of each component.
-
-Here's an example of how you can use the alert component by importing it from the `flowbite-react` package:
+Here's an example of how you can use the alert component by importing it from `flowbite-react`:
 
 ```javascript
 import { Alert } from "flowbite-react";
@@ -207,19 +211,11 @@ function Demo() {
 }
 ```
 
-To learn more about [Flowbite React](https://flowbite-react.com/) make sure to check out to the [repository](https://github.com/themesberg/flowbite-react) and the [main website](https://flowbite-react.com/).
+To learn more about Flowbite React make sure to check out to the [repository](https://github.com/themesberg/flowbite-react) and the [documentation](https://flowbite-react.com/docs/getting-started/introduction).
 
 ## Next.js starter project
 
-The Flowbite community has created an open-source Next.js starter project that has Tailwind CSS and Flowbite React set up beforehand and you can go ahead and clone it by checking out the [repository on GitHub](https://github.com/tulupinc/flowbite-next-starter).
+The open-source community from Flowbite has created a few starter templates that you can find on GitHub or Stackblitz to get you started with the Tailwind CSS, React, Next.js and Flowbite stack:
 
-## Starter templates
-
-#### Official
-
-- [Github](https://github.com/themesberg/flowbite-react-template-nextjs)
-- [StackBlitz](https://stackblitz.com/edit/flowbite-react-template-nextjs)
-
-#### Community
-
-- [Kitchen Sink](https://github.com/tulupinc/flowbite-next-starter) - [Demo](https://flowbite-next-starter.vercel.app/)
+- [Starter template on GitHub](https://github.com/themesberg/flowbite-react-template-nextjs)
+- [Starter template on StackBlitz](https://stackblitz.com/edit/flowbite-react-template-nextjs)

--- a/content/getting-started/next-js.md
+++ b/content/getting-started/next-js.md
@@ -16,22 +16,32 @@ nextLink: getting-started/vue/
 
 This technology is being used by hundreds of thousands of developers and companies such as Vercel, Netflix, TikTok, Twitch, Hulu, Nike and HBO Max since its original release in 2016.
 
-By following this guide you will learn how to properly set up Tailwind CSS with the Flowbite React components inside an existing or new Next.js project.
+By following this guide you will learn how to properly set up [Tailwind CSS](https://tailwindcss.com/) with the [Flowbite React](https://flowbite-react.com/) components inside an existing or new [Next.js](https://nextjs.org/) project.
 
 ## Requirements
 
-Make sure that you have [Node.js](https://nodejs.org/en/) installed on your computer to be able to install Next.js, Tailwind CSS and Flowbite using NPX and NPM.
+Make sure that you have [Node.js](https://nodejs.org/en/) installed on your computer to be able to install [Next.js](https://nextjs.org/), [Tailwind CSS](https://tailwindcss.com/) and [Flowbite React](https://flowbite-react.com/) using `npx` and `npm` commands.
 
 ## Create a Next.js project
 
-1. Run the following command to create a new starter Next.js project:
+### Using the CLI
+
+Run the following command to scaffold a new [Flowbite React](https://flowbite-react.com/) project using [Next.js](https://nextjs.org/):
 
 ```bash
-npx create-next-app@latest --typescript
+npm create flowbite-react@latest -- --template nextjs
+```
+
+### Manual install
+
+1. Run the following command to create a new starter [Next.js](https://nextjs.org/) project:
+
+```bash
+npx create-next-app@latest
 cd my-app
 ```
 
-This command will install all of the necessary dependencies and boilerplate files for a basic Next.js project.
+This command will install all of the necessary dependencies and boilerplate files for a basic [Next.js](https://nextjs.org/) project.
 
 2. Run the following command in your terminal to start a local server:
 
@@ -68,16 +78,20 @@ The `-p` flag will also generate the PostCSS configuration file.
 3. Configure the template paths inside the Tailwind CSS configuration file:
 
 ```javascript
-/**
- * @type {import('@types/tailwindcss/tailwind-config').TailwindConfig}
- */
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./pages/**/*.{ts,tsx}",
-    "./public/**/*.html",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+
+    // Or if using `src` directory:
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
   ],
+  theme: {
+    extend: {},
+  },
   plugins: [],
-  theme: {},
 };
 ```
 
@@ -99,50 +113,31 @@ Follow the steps of the next section in this tutorial to start using a library o
 
 [Flowbite React](https://github.com/themesberg/flowbite-react) is an open-source set of interactive React components based on the Tailwind CSS utility-first framework featuring interactive elements such as modals, navbars, dropdowns, carousels, and more.
 
-1. Install the main Flowbite package and Flowbite React via NPM by running the following command:
+1. Install [Flowbite React](https://flowbite-react.com/) via NPM by running the following command:
 
 ```bash
-npm install flowbite flowbite-react --save
+npm install flowbite-react
 ```
 
-2. Require Flowbite as a plugin inside the `tailwind.config.js` file:
+2. Import [Flowbite React](https://flowbite-react.com/) and add the `plugin` and the `content` path inside your `tailwind.config.js` file:
 
 ```javascript
-/**
- * @type {import('@types/tailwindcss/tailwind-config').TailwindConfig}
- */
+const flowbite = require("flowbite-react/tailwind");
+
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./pages/**/*.{ts,tsx}",
-    "./public/**/*.html",
+    // ...
+    flowbite.content(),
   ],
   plugins: [
-    require("flowbite/plugin")
+    // ...
+    flowbite.plugin(),
   ],
-  theme: {},
 };
 ```
 
-3. Add the source code in the template paths to make sure that dynamic classes from the library will be compiled:
-
-```javascript
-/**
- * @type {import('@types/tailwindcss/tailwind-config').TailwindConfig}
- */
-module.exports = {
-  content: [
-    "./node_modules/flowbite-react/lib/**/*.js",
-    "./pages/**/*.{ts,tsx}",
-    "./public/**/*.html",
-  ],
-  plugins: [
-    require("flowbite/plugin")
-  ],
-  theme: {},
-};
-```
-
-Now that you have successfully installed Flowbite React you can start using the components from the library.
+Now that you have successfully installed [Flowbite React](https://flowbite-react.com/) you can start using the components from the library.
 
 ## Flowbite components
 
@@ -153,7 +148,7 @@ Here's an example of how you can use the alert component by importing it from th
 ```javascript
 import { Alert } from "flowbite-react";
 
-export default function MyPage() {
+function Demo() {
   return <Alert color="info">Alert!</Alert>;
 }
 ```
@@ -161,69 +156,70 @@ export default function MyPage() {
 Here's another example of how you can use the dropdown component:
 
 ```javascript
+"use client";
+
 import { Dropdown } from "flowbite-react";
 
-<Dropdown label="Dropdown button">
-  <Dropdown.Item>
-    Dashboard
-  </Dropdown.Item>
-  <Dropdown.Item>
-    Settings
-  </Dropdown.Item>
-  <Dropdown.Item>
-    Earnings
-  </Dropdown.Item>
-  <Dropdown.Item>
-    Sign out
-  </Dropdown.Item>
-</Dropdown>
+function Demo() {
+  return (
+    <Dropdown label="Dropdown button">
+      <Dropdown.Item>Dashboard</Dropdown.Item>
+      <Dropdown.Item>Settings</Dropdown.Item>
+      <Dropdown.Item>Earnings</Dropdown.Item>
+      <Dropdown.Item>Sign out</Dropdown.Item>
+    </Dropdown>
+  );
+}
 ```
 
 Finally, another example on how you can use the navbar component:
 
 ```javascript
+"use client";
+
 import { Navbar } from "flowbite-react";
 
-<Navbar
-  fluid={true}
-  rounded={true}
->
-  <Navbar.Brand href="https://flowbite.com/">
-    <img
-      src="https://flowbite.com/docs/images/logo.svg"
-      className="mr-3 h-6 sm:h-9"
-      alt="Flowbite Logo"
-    />
-    <span className="self-center whitespace-nowrap text-xl font-semibold dark:text-white">
-      Flowbite
-    </span>
-  </Navbar.Brand>
-  <Navbar.Toggle />
-  <Navbar.Collapse>
-    <Navbar.Link
-      href="/navbars"
-      active={true}
-    >
-      Home
-    </Navbar.Link>
-    <Navbar.Link href="/navbars">
-      About
-    </Navbar.Link>
-    <Navbar.Link href="/navbars">
-      Services
-    </Navbar.Link>
-    <Navbar.Link href="/navbars">
-      Pricing
-    </Navbar.Link>
-    <Navbar.Link href="/navbars">
-      Contact
-    </Navbar.Link>
-  </Navbar.Collapse>
-</Navbar>
+function Demo() {
+  return (
+    <Navbar fluid rounded>
+      <Navbar.Brand href="https://flowbite.com/">
+        <img
+          src="https://flowbite.com/docs/images/logo.svg"
+          className="mr-3 h-6 sm:h-9"
+          alt="Flowbite Logo"
+        />
+        <span className="self-center whitespace-nowrap text-xl font-semibold dark:text-white">
+          Flowbite
+        </span>
+      </Navbar.Brand>
+      <Navbar.Toggle />
+      <Navbar.Collapse>
+        <Navbar.Link href="/navbars" active>
+          Home
+        </Navbar.Link>
+        <Navbar.Link href="/navbars">About</Navbar.Link>
+        <Navbar.Link href="/navbars">Services</Navbar.Link>
+        <Navbar.Link href="/navbars">Pricing</Navbar.Link>
+        <Navbar.Link href="/navbars">Contact</Navbar.Link>
+      </Navbar.Collapse>
+    </Navbar>
+  );
+}
 ```
 
-To learn more about Flowbite React make sure to check out to the repository and the main website.
+To learn more about [Flowbite React](https://flowbite-react.com/) make sure to check out to the [repository](https://github.com/themesberg/flowbite-react) and the [main website](https://flowbite-react.com/).
 
 ## Next.js starter project
 
 The Flowbite community has created an open-source Next.js starter project that has Tailwind CSS and Flowbite React set up beforehand and you can go ahead and clone it by checking out the [repository on GitHub](https://github.com/tulupinc/flowbite-next-starter).
+
+## Starter templates
+
+#### Official
+
+- [Github](https://github.com/themesberg/flowbite-react-template-nextjs)
+- [StackBlitz](https://stackblitz.com/edit/flowbite-react-template-nextjs)
+
+#### Community
+
+- [Kitchen Sink](https://github.com/tulupinc/flowbite-next-starter) - [Demo](https://flowbite-next-starter.vercel.app/)

--- a/content/getting-started/react.md
+++ b/content/getting-started/react.md
@@ -14,23 +14,25 @@ nextLink: getting-started/next-js/
 
 [React](https://react.dev/) is one of the most popular front-end libraries in the world used by websites such as Facebook, Instagram, Yahoo Mail, Dropbox, and more built by the Meta (formerly Facebook) company.
 
-Coupled with [Tailwind CSS](https://tailwindcss.com/) and the React components from Flowbite you will be able to develop applications faster than ever based on the [Flowbite React](https://flowbite-react.com) library.
+Coupled with Tailwind CSS and the React components from Flowbite you will be able to develop applications faster than ever based on the [Flowbite React](https://flowbite-react.com) library using advanced theming functionalities and React specific components and methodologies.
 
 ## Create a React project
 
-The latest recommended way of creating a new React application is to use a front-end tooling software such as [Vite](https://vitejs.dev/) or [Parcel](https://parceljs.org/).
+The latest recommended way of creating a new React application is to use a front-end tooling software such as Vite or Parcel since the React docs no longer recommends the `create-react-app` repository.
 
 ### Using the CLI
 
-Run the following command to scaffold a new [Flowbite React](https://flowbite-react.com/) project using [Vite](https://vitejs.dev/):
+Run the following command to scaffold a new Flowbite React project using [Vite](https://vitejs.dev/):
 
 ```bash
 npm create flowbite-react@latest -- --template vite
 ```
 
+Running this will create a new folder with all the necessary files for a React project with Flowbite.
+
 ### Using Vite React
 
-Create a new React project using [Vite](https://vitejs.dev/) by running the following two commands:
+Create a new React project using Vite by running the following two commands:
 
 ```bash
 npm create vite@latest my-project -- --template react-ts
@@ -41,7 +43,7 @@ Now that the project has been created you can start a local development server b
 
 ## Install Tailwind CSS
 
-1. Install [Tailwind CSS](https://tailwindcss.com/) by running the following two commands:
+1. Install Tailwind CSS by running the following two commands:
 
 ```bash
 npm install -D tailwindcss postcss autoprefixer
@@ -70,15 +72,15 @@ module.exports = {
 
 ## Install Flowbite React
 
-[Flowbite React](https://github.com/themesberg/flowbite-react) is an open-source set of interactive React components based on the Tailwind CSS utility-first framework featuring interactive elements such as modals, navbars, dropdowns, carousels, and more.
+Flowbite React is an open-source set of interactive React components based on the Tailwind CSS utility-first framework featuring interactive elements such as modals, navbars, dropdowns, carousels, and more.
 
-4. Install [Flowbite React](https://flowbite-react.com/) by running the following command in your terminal:
+4. Install Flowbite react by running the following command in your terminal:
 
 ```bash
 npm install flowbite-react
 ```
 
-5. Import [Flowbite React](https://flowbite-react.com/) and add the `plugin` and the `content` path inside your `tailwind.config.js` file:
+5. Import Flowbite React and add the `plugin` and the `content` path inside your `tailwind.config.js` file:
 
 ```javascript
 const flowbite = require("flowbite-react/tailwind");
@@ -102,5 +104,7 @@ You can check out the whole collection of Flowbite components built with React a
 
 ## Starter templates
 
-- [Github](https://github.com/themesberg/flowbite-react-template-vite)
-- [StackBlitz](https://stackblitz.com/edit/flowbite-react-template-vite)
+Use the following open-source starter templates that already have Tailwind CSS, React and Flowbite configured so you can get started with your project right away:
+
+- [Flowbite React Template on GitHub](https://github.com/themesberg/flowbite-react-template-vite)
+- [Flowbite React Template on StackBlitz](https://stackblitz.com/edit/flowbite-react-template-vite)

--- a/content/getting-started/react.md
+++ b/content/getting-started/react.md
@@ -70,6 +70,8 @@ module.exports = {
 @tailwind utilities;
 ```
 
+Now that you have installed Tailwind CSS you can proceed by setting up Flowbite React.
+
 ## Install Flowbite React
 
 Flowbite React is an open-source set of interactive React components based on the Tailwind CSS utility-first framework featuring interactive elements such as modals, navbars, dropdowns, carousels, and more.
@@ -97,6 +99,8 @@ module.exports = {
   ],
 };
 ```
+
+Congratulations! You have successfully now installed all of the required dependencies so you are now ready to start building websites using Tailwind CSS, React and Flowbite.
 
 ## React components
 

--- a/content/getting-started/react.md
+++ b/content/getting-started/react.md
@@ -12,41 +12,36 @@ next: Next.js
 nextLink: getting-started/next-js/
 ---
 
-React is one of the most popular front-end libraries in the world used by websites such as Facebook, Instagram, Yahoo Mail, Dropbox, and more built by the Meta (formerly Facebook) company.
+[React](https://react.dev/) is one of the most popular front-end libraries in the world used by websites such as Facebook, Instagram, Yahoo Mail, Dropbox, and more built by the Meta (formerly Facebook) company.
 
-Coupled with Tailwind CSS and the React components from Flowbite you will be able to develop applications faster than ever based on the [Flowbite React](https://flowbite-react.com) library.
+Coupled with [Tailwind CSS](https://tailwindcss.com/) and the React components from Flowbite you will be able to develop applications faster than ever based on the [Flowbite React](https://flowbite-react.com) library.
 
 ## Create a React project
 
-The latest recommended way of creating a new React application is to use a front-end tooling software such as Vite or Parcel, but you can also use a more classic method such as Create React App.
+The latest recommended way of creating a new React application is to use a front-end tooling software such as [Vite](https://vitejs.dev/) or [Parcel](https://parceljs.org/).
+
+### Using the CLI
+
+Run the following command to scaffold a new [Flowbite React](https://flowbite-react.com/) project using [Vite](https://vitejs.dev/):
+
+```bash
+npm create flowbite-react@latest -- --template vite
+```
 
 ### Using Vite React
 
-1. Create a new React project using Vite by running the following two commands:
+Create a new React project using [Vite](https://vitejs.dev/) by running the following two commands:
 
 ```bash
-npm create vite@latest my-project -- --template react
+npm create vite@latest my-project -- --template react-ts
 cd my-project
 ```
 
 Now that the project has been created you can start a local development server by running `npm run dev` and use the `npm run build` command to create an optimized build for production use.
 
-### Create React App
-
-Follow the next steps to install Tailwind CSS and Flowbite with Create React App.
-
-1. Run the following command in your terminal to create a React application, if you don't already have one:
-
-```bash
-npx create-react-app my-project
-cd my-project
-```
-
-You can now run `npm run start` to start a local server and `npm run build` to create a production build.
-
 ## Install Tailwind CSS
 
-Install Tailwind CSS by running the following two commands:
+1. Install [Tailwind CSS](https://tailwindcss.com/) by running the following two commands:
 
 ```bash
 npm install -D tailwindcss postcss autoprefixer
@@ -57,14 +52,12 @@ npx tailwindcss init -p
 
 ```javascript
 module.exports = {
-  content: [
-    './src/**/*.{js,jsx,ts,tsx}',
-  ],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},
   },
   plugins: [],
-}
+};
 ```
 
 3. Set up the Tailwind directives inside the `./src/index.css` file:
@@ -75,39 +68,39 @@ module.exports = {
 @tailwind utilities;
 ```
 
-## Install Flowbite
+## Install Flowbite React
 
-4. Install Flowbite and Flowbite React by running the following command in your terminal:
+[Flowbite React](https://github.com/themesberg/flowbite-react) is an open-source set of interactive React components based on the Tailwind CSS utility-first framework featuring interactive elements such as modals, navbars, dropdowns, carousels, and more.
+
+4. Install [Flowbite React](https://flowbite-react.com/) by running the following command in your terminal:
 
 ```bash
-npm install flowbite flowbite-react
+npm install flowbite-react
 ```
 
-5. Require Flowbite as a plugin inside your `tailwind.config.js` file:
+5. Import [Flowbite React](https://flowbite-react.com/) and add the `plugin` and the `content` path inside your `tailwind.config.js` file:
 
 ```javascript
+const flowbite = require("flowbite-react/tailwind");
+
+/** @type {import('tailwindcss').Config} */
 module.exports = {
-
-    plugins: [
-        require('flowbite/plugin')
-    ]
-
-}
-```
-
-6. Additionally to your own `content` data you should add the Flowbite source paths to apply the classes from the interactive elements in the `tailwind.config.js` file:
-
-```javascript
-module.exports = {
-
-    content: [
-        // ...
-        'node_modules/flowbite-react/lib/esm/**/*.js'
-    ]
-
-}
+  content: [
+    // ...
+    flowbite.content(),
+  ],
+  plugins: [
+    // ...
+    flowbite.plugin(),
+  ],
+};
 ```
 
 ## React components
 
 You can check out the whole collection of Flowbite components built with React and Tailwind CSS by checking out the [GitHub repository](https://github.com/themesberg/flowbite-react) and the [Flowbite React](https://flowbite-react.com) official documentation.
+
+## Starter templates
+
+- [Github](https://github.com/themesberg/flowbite-react-template-vite)
+- [StackBlitz](https://stackblitz.com/edit/flowbite-react-template-vite)

--- a/content/getting-started/react.md
+++ b/content/getting-started/react.md
@@ -112,3 +112,7 @@ Use the following open-source starter templates that already have Tailwind CSS, 
 
 - [Flowbite React Template on GitHub](https://github.com/themesberg/flowbite-react-template-vite)
 - [Flowbite React Template on StackBlitz](https://stackblitz.com/edit/flowbite-react-template-vite)
+
+## More examples
+
+You can also check out the [pro version of Flowbite](https://flowbite.com/pro/) to get access to over 300+ blocks, templates and an admin dashboard coded with Flowbite React and Tailwind CSS.

--- a/content/getting-started/remix.md
+++ b/content/getting-started/remix.md
@@ -24,6 +24,16 @@ Before getting started make sure you that have [Node.js](https://nodejs.org/en/)
 
 ## Create a Remix project
 
+### Using the CLI
+
+Run the following command to scaffold a new [Flowbite React](https://flowbite-react.com/) project using [Remix](https://remix.run/):
+
+```bash
+npm create flowbite-react@latest -- --template remix
+```
+
+### Manual install
+
 1. Run the following command in your terminal to set up a new Remix project:
 
 ```bash
@@ -131,7 +141,7 @@ If you're running a local server with the `npm run dev` command, then the link s
 npm install flowbite-react
 ```
 
-2. Require Flowbite as a plugin inside the `tailwind.config.ts` file and configure the template paths:
+2. Import [Flowbite React](https://flowbite-react.com/) and add the `plugin` and the `content` path inside your `tailwind.config.ts` file:
 
 ```ts
 import flowbite from "flowbite-react/tailwind";
@@ -228,6 +238,7 @@ export default function Index() {
 }
 ```
 
-## Remix starter project
+## Starter templates
 
-The awesome Flowbite community has created a free and open-source [Remix starter project](https://github.com/themesberg/flowbite-react-template-remix) that you can use pre-configured with Tailwind CSS and the UI components from Flowbite.
+- [Github](https://github.com/themesberg/flowbite-react-template-remix)
+- [StackBlitz](https://stackblitz.com/edit/flowbite-react-template-remix)


### PR DESCRIPTION
### Changes

- [x] rework react-based getting started guides to align with the latest version of `flowbite-react`
- [x] reference the new [Flowbite React CLI](https://flowbite-react.com/docs/getting-started/cli)
- [x] add `Starter templates` section
- [x] format code

### Fixes PRs

#919, #900

### Issues

#892