### PR TITLE
Doc: Update dark-mode.md to fix toggle component link

### DIFF
--- a/content/customize/dark-mode.md
+++ b/content/customize/dark-mode.md
@@ -69,7 +69,7 @@ This will first check if you've previously set the theme color preference manual
 </button>
 ```
 
-In this example we used a `<button>` component where we change the icon inside based on the current color scheme. You can also use other elements, such as the [toggle component]({{< ref "components/forms" >}}).
+In this example we used a `<button>` component where we change the icon inside based on the current color scheme. You can also use other elements, such as the [toggle component](https://flowbite.com/docs/components/forms/#toggle-switch).
 
 3. Add the following JavaScript inside your main file to handle the click events on the `<button>` element:
 


### PR DESCRIPTION
The origin [link](https://flowbite.com/docs/customize/dark-mode/#dark-mode-switcher) brings to the page of the forms component, but not the correct toggle component
![image](https://github.com/user-attachments/assets/8a3da77d-ac2e-4618-82b5-f874251e60dc)
