### PR TITLE
Fix drawer backdrop classes

### DIFF
--- a/src/components/drawer/index.ts
+++ b/src/components/drawer/index.ts
@@ -329,7 +329,9 @@ export function initDrawers() {
             const edgeOffset = $triggerEl.getAttribute(
                 'data-drawer-edge-offset'
             );
-	    const backdropClasses = $triggerEl.getAttribute('data-drawer-backdropClasses');
+            const backdropClasses = $triggerEl.getAttribute(
+                'data-drawer-backdropClasses'
+            );
 
             new Drawer($drawerEl, {
                 placement: placement ? placement : Default.placement,
@@ -345,7 +347,9 @@ export function initDrawers() {
                     : Default.backdrop,
                 edge: edge ? (edge === 'true' ? true : false) : Default.edge,
                 edgeOffset: edgeOffset ? edgeOffset : Default.edgeOffset,
-		backdropClasses: backdropClasses ? backdropClasses : Default.backdropClasses,
+                backdropClasses: backdropClasses
+                    ? backdropClasses
+                    : Default.backdropClasses,
             } as DrawerOptions);
         } else {
             console.error(

--- a/src/components/drawer/index.ts
+++ b/src/components/drawer/index.ts
@@ -329,6 +329,7 @@ export function initDrawers() {
             const edgeOffset = $triggerEl.getAttribute(
                 'data-drawer-edge-offset'
             );
+	    const backdropClasses = $triggerEl.getAttribute('data-drawer-backdropClasses');
 
             new Drawer($drawerEl, {
                 placement: placement ? placement : Default.placement,
@@ -344,6 +345,7 @@ export function initDrawers() {
                     : Default.backdrop,
                 edge: edge ? (edge === 'true' ? true : false) : Default.edge,
                 edgeOffset: edgeOffset ? edgeOffset : Default.edgeOffset,
+		backdropClasses: backdropClasses ? backdropClasses : Default.backdropClasses,
             } as DrawerOptions);
         } else {
             console.error(


### PR DESCRIPTION
I came across the problem that i couldnt add custom backdrop classes to my drawer. 

I found out that the logic is not implemented in the code, which gets the users data attribute to set the custom classes.

This pull request adds the necessary logic to retrieve the data attribute and pass it to the Drawer. If no data attribute is found, it defaults to the ``Default.backdropClasses`` configuration.

This fix is related to [#913](https://github.com/themesberg/flowbite/issues/913).