### PR TITLE
Fix the types for "flowbite/plugin"

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,2 +1,11 @@
-declare const plugin: { handler: () => void };
+declare interface PluginOptions {
+  datatables?: boolean;
+  charts?: boolean;
+  forms?: boolean;
+  tooltips?: boolean;
+}
+declare function plugin(options?: PluginOptions): { handler: () => void };
+declare namespace plugin {
+  function handler(): void;
+}
 export = plugin;


### PR DESCRIPTION
Previously TypeScript would error on `flowbitePlugin({})` with an error about it not being callable. This commit fixes the types.