### PR TITLE
docs(javascript): fix typo

### DIFF
--- a/content/getting-started/javascript.md
+++ b/content/getting-started/javascript.md
@@ -231,7 +231,7 @@ modal.show();
 modal.hide();
 ```
 
-You can even remove the instance form the instance manager:
+You can even remove the instance from the instance manager:
 
 ```javascript
 // remove the instance object from the global FlowbiteInstances manager


### PR DESCRIPTION
I have fixed a small typo in the docs.