### PR TITLE
fix Toogle highlight in wysiwyg.md (issue #981

### DIFF
--- a/content/plugins/wysiwyg.md
+++ b/content/plugins/wysiwyg.md
@@ -135,7 +135,14 @@ window.addEventListener('load', function() {
     document.getElementById('toggleItalicButton').addEventListener('click', () => editor.chain().focus().toggleItalic().run());
     document.getElementById('toggleUnderlineButton').addEventListener('click', () => editor.chain().focus().toggleUnderline().run());
     document.getElementById('toggleStrikeButton').addEventListener('click', () => editor.chain().focus().toggleStrike().run());
-    document.getElementById('toggleHighlightButton').addEventListener('click', () => editor.chain().focus().toggleHighlight({ color: '#ffc078' }).run());
+    document.getElementById('toggleHighlightButton').addEventListener('click', () => {
+    const isHighlighted = editor.isActive('highlight');
+    // when using toggleHighlight(), judge if is is already highlighted.
+    editor.chain().focus().toggleHighlight({
+        color: isHighlighted ? undefined : '#ffc078' // if is already highlighted，unset the highlight color
+    }).run();
+    });
+
     document.getElementById('toggleLinkButton').addEventListener('click', () => {
         const url = window.prompt('Enter image URL:', 'https://flowbite.com');
         editor.chain().focus().toggleLink({ href: url }).run();
@@ -759,7 +766,14 @@ window.addEventListener('load', function() {
     document.getElementById('toggleStrikeButton').addEventListener('click', () => editor.chain().focus().toggleStrike().run());
     document.getElementById('toggleSubscriptButton').addEventListener('click', () => editor.chain().focus().toggleSubscript().run());
     document.getElementById('toggleSuperscriptButton').addEventListener('click', () => editor.chain().focus().toggleSuperscript().run());
-    document.getElementById('toggleHighlightButton').addEventListener('click', () => editor.chain().focus().toggleHighlight({ color: '#ffc078' }).run());
+    document.getElementById('toggleHighlightButton').addEventListener('click', () => {
+    const isHighlighted = editor.isActive('highlight');
+    // when using toggleHighlight(), judge if is is already highlighted.
+    editor.chain().focus().toggleHighlight({
+        color: isHighlighted ? undefined : '#ffc078' // if is already highlighted，unset the highlight color
+    }).run();
+    });
+
     document.getElementById('toggleCodeButton').addEventListener('click', () => {
         editor.chain().focus().toggleCode().run();
     });


### PR DESCRIPTION
## Pull Request Description

### Summary

This pull request addresses the issue #981 where the "Toggle Highlight" feature in the `WYSIWYG` text editor was not functioning correctly. Users could apply highlights to text, but they were unable to remove the highlight once applied.

### Changes Made

- **Fixed Toggle Highlight Functionality**: 
  - Updated the code logic to ensure that the highlight can now be toggled off as well as on.
  - Ensured that the editor state updates correctly when the highlight is removed.

### Steps to Test

1. Open the WYSIWYG text editor.
2. Select some text and click the `Toggle highlight` button to apply a highlight.
3. Click the "Highlight" button again to remove the highlight.
4. Verify that the highlight is successfully removed.

### Outcome Screenshots


https://github.com/user-attachments/assets/dd04ef17-4fef-4f08-af73-415d5d6161e2


### Additional Notes

- This fix improves the usability of the text editor by allowing users to easily manage text highlights.
- Please review the changes and let me know if any further modifications are needed.

Thank you for considering this update!