### PR TITLE
remove inactive classes before adding active classes when showing an accordion item

### DIFF
--- a/src/components/accordion/index.ts
+++ b/src/components/accordion/index.ts
@@ -120,10 +120,10 @@ class Accordion implements AccordionInterface {
         }
 
         // show active item
-        item.triggerEl.classList.add(...this._options.activeClasses.split(' '));
         item.triggerEl.classList.remove(
             ...this._options.inactiveClasses.split(' ')
         );
+        item.triggerEl.classList.add(...this._options.activeClasses.split(' '));
         item.triggerEl.setAttribute('aria-expanded', 'true');
         item.targetEl.classList.remove('hidden');
         item.active = true;


### PR DESCRIPTION
To prevent removal of classes present in both `activeClasses` and `inactiveClasses` when the accordion item is shown. Fixes #1005 