### PR TITLE
Reinitialize properly on Form Validation Errors for Turbo

### DIFF
--- a/src/index.turbo.ts
+++ b/src/index.turbo.ts
@@ -28,8 +28,11 @@ addEventListener('turbo:before-stream-render', (event: CustomEvent) => {
     };
 });
 
-const turboLoadEvents = new Events('turbo:load', [initFlowbite]);
-turboLoadEvents.init();
+const domContentLoadedEvents = new Events('DOMContentLoaded', [initFlowbite]);
+domContentLoadedEvents.init();
+
+const turboRenderEvents = new Events('turbo:render', [initFlowbite]);
+turboRenderEvents.init();
 
 const turboFrameLoadEvents = new Events('turbo:frame-load', [initFlowbite]);
 turboFrameLoadEvents.init();


### PR DESCRIPTION
In the current integration, the turbo:load event doesn't capture every Turbo render—for example, forms that fail validation (returning a 422 status) aren't caught. Instead, turbo:render handles those cases and also covers all events that turbo:load does, except for the initial page load. To address this, I use DOMContentLoaded to ensure the initial load is handled properly.