### PR TITLE
Respect StreamElement.render async function

### DIFF
--- a/src/index.turbo.ts
+++ b/src/index.turbo.ts
@@ -22,8 +22,8 @@ const afterRenderEvent = new Event('turbo:after-stream-render');
 addEventListener('turbo:before-stream-render', (event: CustomEvent) => {
     const originalRender = event.detail.render;
 
-    event.detail.render = function (streamElement: Element) {
-        originalRender(streamElement);
+    event.detail.render = async function (streamElement: Element) {
+        await originalRender(streamElement);
         window.dispatchEvent(afterRenderEvent);
     };
 });


### PR DESCRIPTION
The StreamElement.render property is set to an async function in Turbo (see https://github.com/hotwired/turbo/blob/main/src/elements/stream_element.js#L29 and https://github.com/hotwired/turbo/blob/main/src/elements/stream_element.js#L167). As a result we should respect the async nature of the function and only dispatch the after render event once we know rendering has completed, by awaiting render to finish.