### PR TITLE
Add "Sign in with X" social button to Social Buttons component

### DIFF
--- a/content/components/buttons.md
+++ b/content/components/buttons.md
@@ -163,6 +163,12 @@ Use these button styles when building social media login forms using Facebook, T
 </svg>
 Sign in with Facebook
 </button>
+<button type="button" class="text-white bg-[#050708] hover:bg-[#050708]/90 focus:ring-4 focus:outline-none focus:ring-[#050708]/50 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:focus:ring-[#050708]/50 dark:hover:bg-[#050708]/30 me-2 mb-2">
+  <svg class="w-4 h-4 me-2 -ms-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 512 512">
+    <path fill="currentColor" fill-rule="evenodd" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z" clip-rule="evenodd" />
+  </svg>
+  Sign in with X
+</button> 
 <button type="button" class="text-white bg-[#1da1f2] hover:bg-[#1da1f2]/90 focus:ring-4 focus:outline-none focus:ring-[#1da1f2]/50 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:focus:ring-[#1da1f2]/55 me-2 mb-2">
 <svg class="w-4 h-4 me-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 17">
 <path fill-rule="evenodd" d="M20 1.892a8.178 8.178 0 0 1-2.355.635 4.074 4.074 0 0 0 1.8-2.235 8.344 8.344 0 0 1-2.605.98A4.13 4.13 0 0 0 13.85 0a4.068 4.068 0 0 0-4.1 4.038 4 4 0 0 0 .105.919A11.705 11.705 0 0 1 1.4.734a4.006 4.006 0 0 0 1.268 5.392 4.165 4.165 0 0 1-1.859-.5v.05A4.057 4.057 0 0 0 4.1 9.635a4.19 4.19 0 0 1-1.856.07 4.108 4.108 0 0 0 3.831 2.807A8.36 8.36 0 0 1 0 14.184 11.732 11.732 0 0 0 6.291 16 11.502 11.502 0 0 0 17.964 4.5c0-.177 0-.35-.012-.523A8.143 8.143 0 0 0 20 1.892Z" clip-rule="evenodd"/>


### PR DESCRIPTION
## Description

This pull request adds a new "Sign in with X" social button alongside existing social login options (Facebook, Twitter, GitHub, Google, and Apple) under the Social Buttons section.

- Styled the button to match the existing button styles (black background, white text, rounded edges).
- Added the corresponding SVG icon and label.
- Tested visually on desktop and mobile views using Chrome DevTools for responsiveness and consistency.

## Motivation

Currently, the "Sign in with X" button is missing from the social buttons list. This addition helps keep the Flowbite components updated with major social platforms and enhances the user options.

## Screenshots

![Screenshot 2025-04-26 at 9 35 24 AM](https://github.com/user-attachments/assets/07d1bbb7-73f2-47e4-b939-230acfbd9bdb)

![Screenshot 2025-04-26 at 9 35 49 AM](https://github.com/user-attachments/assets/24373bf9-2b47-4e4a-915c-c291d6589c01)

---

✅ Ready for review.

