### PR TITLE
Close dropdown on `Escape` key press, fixing Issue #1064

### DIFF
--- a/src/components/dropdown/index.ts
+++ b/src/components/dropdown/index.ts
@@ -39,6 +39,7 @@ class Dropdown implements DropdownInterface {
     _hoverShowTargetElHandler: EventListenerOrEventListenerObject;
     _hoverHideHandler: EventListenerOrEventListenerObject;
     _clickHandler: EventListenerOrEventListenerObject;
+    _keydownEventListener: EventListenerOrEventListenerObject;
 
     constructor(
         targetElement: HTMLElement | null = null,
@@ -101,6 +102,8 @@ class Dropdown implements DropdownInterface {
             });
         }
 
+        document.removeEventListener('keydown', this._keydownEventListener);
+
         this._popperInstance.destroy();
         this._initialized = false;
     }
@@ -127,6 +130,16 @@ class Dropdown implements DropdownInterface {
                 this._triggerEl.addEventListener(ev, this._clickHandler);
             });
         }
+
+        this._keydownEventListener = (ev: KeyboardEvent) => {
+            if (ev.key === 'Escape') {
+                if (this.isVisible()) {
+                    this.hide();
+                }
+            }
+        };
+
+        document.addEventListener('keydown', this._keydownEventListener);
 
         this._hoverShowTriggerElHandler = (ev) => {
             if (ev.type === 'click') {

--- a/src/components/dropdown/interface.ts
+++ b/src/components/dropdown/interface.ts
@@ -13,6 +13,7 @@ export declare interface DropdownInterface {
     _popperInstance: PopperInstance;
     _initialized: boolean;
     _clickOutsideEventListener: EventListenerOrEventListenerObject;
+    _keydownEventListener: EventListenerOrEventListenerObject;
 
     init(): void;
     _createPopperInstance(): PopperInstance;


### PR DESCRIPTION
Implement functionality to close the dropdown menu when the `Escape` key is pressed. 
This enhances user experience by providing a quick way to dismiss the dropdown.

Fixes Issue #1064

Refs: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/