### PR TITLE
Modal: Implement focus trap

### DIFF
--- a/src/components/modal/interface.ts
+++ b/src/components/modal/interface.ts
@@ -17,6 +17,10 @@ export declare interface ModalInterface {
 
     _keydownEventListener: EventListenerOrEventListenerObject;
 
+    // Focus trap related properties
+    _lastActiveElement: HTMLElement | null;
+    _focusTrapEventListener: EventListenerOrEventListenerObject;
+
     // Initializes the modal and sets up its event listeners
     init(): void;
 
@@ -28,6 +32,15 @@ export declare interface ModalInterface {
 
     // Sets up event listeners for the modal to allow it to be closed when clicked outside or the Escape key is pressed
     _setupModalCloseEventListeners(): void;
+
+    // Sets up focus trapping within the modal
+    _setupFocusTrap(): void;
+
+    // Removes focus trap event listeners
+    _removeFocusTrap(): void;
+
+    // Gets all focusable elements within the modal
+    _getFocusableElements(): HTMLElement[];
 
     // Handles clicks outside the modal and hides it if necessary
     _handleOutsideClick(target: EventTarget): void;


### PR DESCRIPTION
This PR proposes a solution to trap focus within a modal. This improves keyboard navigation and overall accessibility.

According to [Focus Order (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html) from [WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/) - _A web page implements modal dialogs via scripting. When the trigger button is activated, a dialog opens and focus is set within the dialog. As long as the dialog is open, focus is limited to the elements of the dialog. When the dialog is dismissed, focus returns to the button or the element following the button._

I previously submitted a similar [PR](https://github.com/themesberg/flowbite-vue/pull/367) to [Flowbite Vue](https://github.com/themesberg/flowbite-vue).