### PR TITLE
Allow the overriding of active/inactive classes for indicators in carousels

### DIFF
--- a/src/components/carousel/index.ts
+++ b/src/components/carousel/index.ts
@@ -350,10 +350,15 @@ export function initCarousels() {
             });
         }
 
+        const indicatorActiveClasses = $carouselEl.getAttribute('data-carousel-indicator-active-classes');
+        const indicatorInactiveClasses = $carouselEl.getAttribute('data-carousel-indicator-inactive-classes');
+
         const carousel = new Carousel($carouselEl as HTMLElement, items, {
             defaultPosition: defaultPosition,
             indicators: {
                 items: indicators,
+                activeClasses: indicatorActiveClasses ? indicatorActiveClasses : Default.indicators.activeClasses,
+                inactiveClasses: indicatorInactiveClasses ? indicatorInactiveClasses : Default.indicators.inactiveClasses,
             },
             interval: interval ? interval : Default.interval,
         } as CarouselOptions);


### PR DESCRIPTION
Allow the overriding of active/inactive classes for indicators in carousels

```html
<div 
    id="default-carousel" 
    class="relative w-full" 
    data-carousel="slide" 
    data-carousel-indicator-active-classes="bg-white" 
    data-carousel-indicator-inactive-classes="bg-black"
    >
... other carousel code ...
</div>
```

Relates to #810 