### PR TITLE
[BUG] Added missing var function

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -277,7 +277,7 @@ module.exports = plugin.withOptions(function (options = {}) {
                     width: spacing[4],
                     color: 'var(--color-blue-600)',
                     'background-color': '#fff',
-                    'border-color': '--color-gray-500',
+                    'border-color': 'var(--color-gray-500)',
                     'border-width': borderWidth['DEFAULT'],
                     '--tw-shadow': '0 0 #0000',
                 },


### PR DESCRIPTION
This variable is not wrapped with `var()` which causes browsers to treat it as invalid.

<img width="478" height="267" alt="image" src="https://github.com/user-attachments/assets/e2582e75-d5d0-46ca-a38e-ec0018a18f77" />
