### PR TITLE
fix: Top-left radius not showing in card

### DIFF
--- a/content/components/card.md
+++ b/content/components/card.md
@@ -649,7 +649,7 @@ Use this example to split cards into multiple sections such as for testimonials 
 {{< example id="card-testimonial-example" github="components/card.md" show_dark=true >}}
 
 <div class="grid mb-8 border border-gray-200 rounded-lg shadow-xs dark:border-gray-700 md:mb-12 md:grid-cols-2 bg-white dark:bg-gray-800">
-    <figure class="flex flex-col items-center justify-center p-8 text-center bg-white border-b border-gray-200 rounded-t-lg md:rounded-t-none md:rounded-ss-lg md:border-e dark:bg-gray-800 dark:border-gray-700">
+    <figure class="flex flex-col items-center justify-center p-8 text-center bg-white border-b border-gray-200 rounded-t-lg md:rounded-se-none md:rounded-ss-lg md:border-e dark:bg-gray-800 dark:border-gray-700">
         <blockquote class="max-w-2xl mx-auto mb-4 text-gray-500 lg:mb-8 dark:text-gray-400">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Very easy this was to integrate</h3>
             <p class="my-4">If you care for your time, I hands down would go with this."</p>


### PR DESCRIPTION
The previous tailwind class `md:rounded-t-none` would generate this issue in the top-left radius of "Testimonial card":

<img width="165" height="93" alt="image" src="https://github.com/user-attachments/assets/d224641e-0e5b-456d-9678-ce46b0a34af2" />
