### PR TITLE
Initialize Popper without event listeners

### DIFF
--- a/src/components/dropdown/index.ts
+++ b/src/components/dropdown/index.ts
@@ -182,6 +182,10 @@ class Dropdown implements DropdownInterface {
                         ],
                     },
                 },
+                {
+                    name: 'eventListeners',
+                    enabled: false
+                },
             ],
         });
     }

--- a/src/components/popover/index.ts
+++ b/src/components/popover/index.ts
@@ -143,6 +143,10 @@ class Popover implements PopoverInterface {
                         offset: [0, this._options.offset],
                     },
                 },
+                {
+                    name: 'eventListeners',
+                    enabled: false
+                },
             ],
         });
     }

--- a/src/components/tooltip/index.ts
+++ b/src/components/tooltip/index.ts
@@ -133,6 +133,10 @@ class Tooltip implements TooltipInterface {
                         offset: [0, 8],
                     },
                 },
+                {
+                    name: 'eventListeners',
+                    enabled: false
+                },
             ],
         });
     }


### PR DESCRIPTION
* event listeners are only needed when the popup is actually visible

Note: Event Listeners were already disabled on hide

Fixes performance issues mentioned in #307