### PR TITLE
fix: correct method calls in Modal show() and hide() methods

### DIFF
--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -187,7 +187,7 @@ class Modal implements ModalInterface {
     }
 
     show() {
-        if (this.isHidden) {
+        if (this.isHidden()) {
             this._targetEl.classList.add('flex');
             this._targetEl.classList.remove('hidden');
             this._targetEl.setAttribute('aria-modal', 'true');
@@ -210,7 +210,7 @@ class Modal implements ModalInterface {
     }
 
     hide() {
-        if (this.isVisible) {
+        if (this.isVisible()) {
             this._targetEl.classList.add('hidden');
             this._targetEl.classList.remove('flex');
             this._targetEl.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
## Description
This PR fixes a critical bug in the Modal component where `isHidden` and `isVisible` were being called as properties instead of methods.

## Bug Details
In the `show()` and `hide()` methods, the code was checking:
- `if (this.isHidden)` instead of `if (this.isHidden())`
- `if (this.isVisible)` instead of `if (this.isVisible())`

Since these are methods, calling them without parentheses returns the function reference (which is always truthy), causing the conditions to always evaluate to `true`. This means:
- The `show()` method would always execute its logic, even if the modal was already visible
- The `hide()` method would always execute its logic, even if the modal was already hidden

## Changes
- Line 213: `this.isHidden` → `this.isHidden()`
- Line 230: `this.isVisible` → `this.isVisible()`

## Impact
This bug could cause:
- Multiple event listeners being attached
- Incorrect state management
- Potential memory leaks
- Unexpected behavior when calling show/hide multiple times

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
