### PR TITLE
FIX: Missing turbo:render event listener

### DIFF
--- a/src/index.turbo.ts
+++ b/src/index.turbo.ts
@@ -39,6 +39,9 @@ const turboStreamLoadEvents = new Events('turbo:after-stream-render', [
 ]);
 turboStreamLoadEvents.init();
 
+const turboRenderEvents = new Events('turbo:render', [initFlowbite]);
+turboRenderEvents.init();
+
 export default {
     Accordion,
     Carousel,


### PR DESCRIPTION
Flowbite components stop working after form validation errors in Rails. They work on initial page load but become unresponsive after Turbo re-renders the page with a 422 response.

https://github.com/themesberg/flowbite/issues/1111