### PR TITLE
fix(modal): add turbo-permanent attributes to backdrop to prevent removal during morph

### DIFF
--- a/src/index.turbo.ts
+++ b/src/index.turbo.ts
@@ -16,6 +16,17 @@ import Datepicker from './components/datepicker';
 import { initFlowbite } from './components/index';
 import Events from './dom/events';
 
+// Patch Modal to add Turbo-compatible attributes to backdrop
+// This prevents Turbo Morph from removing dynamically created backdrop elements
+const originalCreateBackdrop = Modal.prototype._createBackdrop;
+Modal.prototype._createBackdrop = function () {
+    originalCreateBackdrop.call(this);
+    if (this._backdropEl) {
+        this._backdropEl.setAttribute('data-turbo-permanent', '');
+        this._backdropEl.setAttribute('data-turbo-temporary', '');
+    }
+};
+
 // Since turbo maintainers refuse to add this event, we'll add it ourselves
 // https://discuss.hotwired.dev/t/event-to-know-a-turbo-stream-has-been-rendered/1554/10
 const afterRenderEvent = new Event('turbo:after-stream-render');


### PR DESCRIPTION
## Summary

- Add `data-turbo-permanent` and `data-turbo-temporary` attributes to the dynamically created backdrop element to prevent Turbo Morph from removing it during page refresh

## Problem

When using Flowbite Modal with Turbo (Rails 8) and `turbo_stream.refresh` with Morph, the dynamically created backdrop element is removed during the morph process. This causes the modal to appear broken (no backdrop) or close unexpectedly.

The issue is that Turbo Morph compares the current DOM with the server response and removes elements that don't exist in the response. Since the backdrop is dynamically created by JavaScript and not present in the server HTML, it gets removed.

## Solution

Add two data attributes to the backdrop element when it's created:

- `data-turbo-permanent`: Tells Turbo to preserve this element during morph/refresh
- `data-turbo-temporary`: Tells Turbo not to cache this element (prevents duplicate backdrops on browser back)

## Testing

1. Create a Rails 8 app with Turbo and Flowbite
2. Open a Flowbite modal
3. Trigger `turbo_stream.refresh` from the server
4. Before: backdrop disappears, modal breaks
5. After: modal and backdrop remain visible and functional

## Related Issues

Fixes #1123