### PR TITLE
docs: add uv installation instructions to Django guide

### DIFF
--- a/content/getting-started/django.md
+++ b/content/getting-started/django.md
@@ -22,23 +22,44 @@ By following this guide you will learn how to properly set up a Django project w
 
 Follow the next steps to create a new Django project and install Tailwind CSS with Flowbite to get the full benefits of the component library.
 
-Make sure that you have both [Node.js](https://nodejs.org) and [Python](https://www.python.org/) installed on your local machine.
+Make sure that you have both [Node.js](https://nodejs.org) and [Python](https://www.python.org/) installed on your local machine. If you are using `uv` for python package management ensure you have [uv](https://docs.astral.sh/uv/) installed.
 
-After that, you'll need to install Django on your local computer by following the official [installation guide](https://docs.djangoproject.com/en/4.0/intro/install/) or by running the following command in the terminal if you have pip available in your Python environment:
+After that, you'll need to install Django on your local computer by following the official [installation guide](https://docs.djangoproject.com/en/4.0/intro/install/) or by running the following command in the terminal using `pip` or if you are using `uv`:
+
+
+**Using pip:**
 
 {{< code lang="bash" >}}
 python -m pip install Django
+{{< /code >}}
+
+**Using uv:**
+
+{{< code lang="bash" >}}
+uv add django
 {{< /code >}}
 
 Now that you have all the required technologies installed you can start by creating a new Django project.
 
 ## Create a Django project
 
+
 1. Run the following command in the terminal to create a new Django project with the name `flowbiteapp`:
+
+**Using pip:**
 
 {{< code lang="bash" >}}
 django-admin startproject flowbiteapp
 cd flowbiteapp/
+{{< /code >}}
+
+**Using uv:**
+
+{{< code lang="bash" >}}
+uv init flowbiteapp
+cd flowbiteapp
+uv add django
+uv run django-admin startproject flowbiteapp .
 {{< /code >}}
 
 2. Create a new `templates/` directory inside the project folder and then update the existing `settings.py` file:
@@ -53,10 +74,18 @@ TEMPLATES = [
 ]
 {{< /code >}}
 
-3. Installed `django-compressor` by running the following command in your terminal:
+3. Install `django-compressor` by running the following command in your terminal:
+
+**Using pip:**
 
 {{< code lang="bash" >}}
 python -m pip install django-compressor
+{{< /code >}}
+
+**Using uv:**
+
+{{< code lang="bash" >}}
+uv add django-compressor
 {{< /code >}}
 
 4. Add `compressor` and `flowbiteapp` (or the name of your app) to the installed apps inside the `settings.py` file:


### PR DESCRIPTION
## Description
This PR adds installation instructions using **uv** (by Astral) to the Django "Getting Started" guide. 

As `uv` is rapidly becoming a preferred package manager in the Python ecosystem due to its speed and environment management capabilities, providing these alternatives alongside `pip` makes the documentation more modern and accessible for different developer workflows.

## Changes
- Added `uv` commands for Django installation.
- Added `uv` commands for project initialization.
- Added `uv` commands for `django-compressor` installation.
- Maintained consistency with existing documentation styling (using the `{{< code >}}` shortcode).

## Screenshots 
 **Requirements** 
<img width="1323" height="442" alt="image" src="https://github.com/user-attachments/assets/bf707140-1a28-46ad-a50e-dbbd57620c3b" />

<img width="944" height="560" alt="Screenshot from 2026-04-23 22-55-01" src="https://github.com/user-attachments/assets/97790ec7-a2b4-4eb2-9f86-8d1f872d663d" />


**Project Setup**
<img width="956" height="404" alt="image" src="https://github.com/user-attachments/assets/6427ce2f-b078-451e-9582-cc9b17c61d4f" />

<img width="950" height="416" alt="Screenshot from 2026-04-23 22-55-53" src="https://github.com/user-attachments/assets/275194d4-3e35-441f-b200-91bf8be6d8a1" />



## Checklist
- [x] Verified changes locally using `hugo server`.
- [x] Verified that multi-line commands render correctly.
- [x] No changes made to `package.json` or `package-lock.json`.

##The Why
`uv` is a modern, fast alternative to `pip` and adding this option helps Python developers who prefer the astral-sh ecosystem.